### PR TITLE
Fix #4 js client connection timeout exception

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -119,6 +119,7 @@ window.MessageBus = (function() {
       },
       success: function(messages) {
         failCount = 0;
+        if (messages === null) return; // server unexpectedly closed connection
         $.each(messages,function(_,message) {
           gotData = true;
           $.each(callbacks, function(_,callback) {


### PR DESCRIPTION
If the server closes the connection without a reply, eg. because a
timeout was hit before the `MessageBus.long_polling_interval` or due to a
server restart, the success callback is called with null data.
The code no handles this gracefully instead of raising a TypeError
inside jQuery.each trying to call object.length on messages.
This case is not counted as an error, because we usually can reconnect
just fine instantly.
