### PR TITLE
Change default long polling interval to 29 seconds

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -88,7 +88,7 @@ module MessageBus::Implementation
   end
 
   def long_polling_interval
-    @long_polling_interval || 30 * 1000
+    @long_polling_interval || 29 * 1000
   end
 
   def off

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -59,7 +59,7 @@ describe MessageBus::Rack::Middleware do
         MessageBus.long_polling_interval = 10
         s = Time.now.to_f * 1000
         post "/message-bus/ABC", '/foo' => nil
-        (Time.now.to_f * 1000 - s).should < 30
+        (Time.now.to_f * 1000 - s).should < 29
       ensure
         MessageBus.long_polling_interval = 5000
       end


### PR DESCRIPTION
This is related to issue #4: When running on Thin, connections time out
after 30 seconds. So in order to avoid race conditions, we need to send
our reply to the client slightly earlier.
In most other server setups you should be fine with 59 seconds.
