### PR TITLE
Add license and homepage to gemspec.

### DIFF
--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |gem|
   gem.email         = ["sam.saffron@gmail.com"]
   gem.description   = %q{A message bus for rack}
   gem.summary       = %q{}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/SamSaffron/message_bus"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I frequently lookup a gems homepage/repo_url RubyGems (e.g. 
https://rubygems.org/gems/message_bus). These settings will be picked up by
rubygems.org upon publishing the next version.

I also added the license (MIT) to the gemspec.
