### PR TITLE
Fix setting of MessageBus baseUrl and clientId

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -109,7 +109,7 @@ window.MessageBus = (function() {
     lastAjax = new Date();
     totalAjaxCalls += 1;
 
-    return $.ajax(baseUrl + "message-bus/" + clientId + "/poll?" + (!shouldLongPoll() || !me.enableLongPolling ? "dlp=t" : ""), {
+    return $.ajax(me.baseUrl + "message-bus/" + me.clientId + "/poll?" + (!shouldLongPoll() || !me.enableLongPolling ? "dlp=t" : ""), {
       data: data,
       cache: false,
       dataType: 'json',


### PR DESCRIPTION
This should fix issue #15. Without this change it is not possible to change the baseUrl and clientId.
