### PR TITLE
Zepto compat: pass the poll url to $.ajax via settings instead of the first argument

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -108,8 +108,9 @@ window.MessageBus = (function() {
     var aborted = false;
     lastAjax = new Date();
     totalAjaxCalls += 1;
-
-    return $.ajax(me.baseUrl + "message-bus/" + me.clientId + "/poll?" + (!shouldLongPoll() || !me.enableLongPolling ? "dlp=t" : ""), {
+    
+    return $.ajax({
+      url: me.baseUrl + "message-bus/" + me.clientId + "/poll?" + (!shouldLongPoll() || !me.enableLongPolling ? "dlp=t" : ""),
       data: data,
       cache: false,
       dataType: 'json',


### PR DESCRIPTION
Zepto does not want to have url as the first argument, so we put it into the options object instead. The jQuery docs do show examples where `url` is passed as part of the settings object, so I think the use is still legal.
