### PR TITLE
Unsubscribe single func

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -235,7 +235,7 @@ window.MessageBus = (function() {
         glob = true;
       }
       callbacks = $.grep(callbacks,function(callback) {
-        var funcMismatch = (typeof(func) !== 'function') || (callback.func !== func);
+        var funcMismatch = callback.func !== func;
         if (glob) {
           return (callback.channel.substr(0, channel.length) !== channel) || funcMismatch;
         } else {


### PR DESCRIPTION
Our application has multiple components subscribed to the same channel.  The current unsubscribe deletes all functions listening to a channel.

This change allows the user to pass in the function used for subscribe, and only that function is unsubscribed.
