### PR TITLE
Use callbackInterval/backgroundCallbackInterval

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -124,7 +124,7 @@ window.MessageBus = (function() {
         var interval;
         try {
           if (gotData || aborted) {
-            interval = 100;
+            interval = shouldLongPoll() ? me.callbackInterval : me.backgroundCallbackInterval;
           } else {
             interval = me.callbackInterval;
             if (failCount > 2) {


### PR DESCRIPTION
The interval between ajax requests to the server was manually set to
100. Now we use the defined/overrideable properties on the the
MessageBus object to control the duration of time inbetween requests.