### PR TITLE
use max_backlog_size parameter

### DIFF
--- a/lib/message_bus/reliable_pub_sub.rb
+++ b/lib/message_bus/reliable_pub_sub.rb
@@ -27,7 +27,7 @@ class MessageBus::ReliablePubSub
   # max_backlog_size is per multiplexed channel
   def initialize(redis_config = {}, max_backlog_size = 1000)
     @redis_config = redis_config
-    @max_backlog_size = 1000
+    @max_backlog_size = max_backlog_size
     # we can store a lot of messages, since only one queue
     @max_global_backlog_size = 100000
     @max_publish_retries = 10

--- a/spec/lib/reliable_pub_sub_spec.rb
+++ b/spec/lib/reliable_pub_sub_spec.rb
@@ -47,6 +47,10 @@ describe MessageBus::ReliablePubSub do
     ]
   end
 
+  it "should initialize with max_backlog_size" do
+    MessageBus::ReliablePubSub.new({},2000).max_backlog_size.should == 2000
+  end
+
   it "should truncate channels correctly" do
     @bus.max_backlog_size = 2
     4.times do |t|


### PR DESCRIPTION
Actually use max_backlog_size parameter (that is already provided) when initializing ReliablePubSub.