### PR TITLE
allow providing xhrFields like 'withCredentials' for CORS

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -10,7 +10,7 @@
 window.MessageBus = (function() {
   // http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript
   var callbacks, clientId, failCount, shouldLongPoll, queue, responseCallbacks, uniqueId, baseUrl;
-  var me, started, stopped, longPoller, pollTimeout, paused, later;
+  var me, started, stopped, longPoller, pollTimeout, paused, later, xhrFields;
 
   uniqueId = function() {
     return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
@@ -30,6 +30,7 @@ window.MessageBus = (function() {
   baseUrl = "/";
   paused = false;
   later = [];
+  xhrFields = {};
 
   var hiddenProperty;
 
@@ -100,6 +101,7 @@ window.MessageBus = (function() {
       headers: {
         'X-SILENCE-LOGGER': 'true'
       },
+      xhrFields: me.xhrFields,
       success: function(messages) {
         failCount = 0;
         if (paused) {


### PR DESCRIPTION
When connecting to long-polled server on a different domain/port you might want to share authorization cookies with it, so you have to add xhrFields { withCredentials: true } to ajax calls.
This patch would enable doing this.