### PR TITLE
allow overriding longPoller

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -162,6 +162,7 @@ window.MessageBus = (function() {
     callbacks: callbacks,
     clientId: clientId,
     alwaysLongPoll: false,
+    longPoller: longPoller,
     baseUrl: baseUrl,
     // TODO we can make the dependency on $ and jQuery conditional
     // all we really need is an implementation of ajax
@@ -219,7 +220,7 @@ window.MessageBus = (function() {
           data[callback.channel] = callback.last_id;
         });
 
-        me.longPoll = longPoller(poll,data);
+        me.longPoll = me.longPoller(poll,data);
       };
 
 


### PR DESCRIPTION
Now I wanted to supply some more data to the backend, but couldn't, since longPoller wasn't exposed. This would help. (Or is there a better way to add properties to data?)

When adding data this way, you have to make sure to delete it from env['rack.request.form_hash'] before passing env on to MessageBus middleware - otherwise it can lead to errors when MessageBus tries to convert that data to channels.