### PR TITLE
Changes redis_channel_prefix from discourse_ to _message_bus_

### DIFF
--- a/lib/message_bus/redis/reliable_pub_sub.rb
+++ b/lib/message_bus/redis/reliable_pub_sub.rb
@@ -48,7 +48,7 @@ class MessageBus::Redis::ReliablePubSub
 
   def redis_channel_name
     db = @redis_config[:db] || 0
-    "discourse_#{db}"
+    "_message_bus_#{db}"
   end
 
   # redis connection used for publishing messages


### PR DESCRIPTION
As per #37 