### PR TITLE
Add redis configuration info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ MessageBus.subscribe("/channel", function(data){
 
 ```
 
+## Configuration
+
+### Redis
+
+You can configure redis setting in `config/initializers/message_bus.rb`, like
+
+```ruby
+MessageBus.redis_config = { url: "redis://:p4ssw0rd@10.0.1.1:6380/15" }
+```
+The redis client message_bus uses is [redis-rb](https://github.com/redis/redis-rb), so you can visit it's repo to see what options you can configure.
+
+
 ## Similar projects
 
 Faye - http://faye.jcoglan.com/


### PR DESCRIPTION
Hello, recently I am trying to configure my message_bus's redis connection, and I found the api by reading the source code. And I think it would be helpful if everyone can know how to do it by just reading the readme.