### PR TITLE
Support for json post data

### DIFF
--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -85,7 +85,14 @@ class MessageBus::Rack::Middleware
                                     user_id: user_id, site_id: site_id, group_ids: group_ids)
 
     request = Rack::Request.new(env)
-    request.POST.each do |k,v|
+
+    post_data = if request.form_data?
+      request.POST
+    else
+      JSON.parse env['rack.input'].read
+    end
+
+    post_data.each do |k,v|
       client.subscribe(k, v)
     end
 

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -124,6 +124,16 @@ describe MessageBus::Rack::Middleware do
 
       test.should == [1]
     end
+
+    it "should support json post data" do
+      header "Content-Type", "application/json"
+      post "/message-bus/ABC", {'/foo' => -1}.to_json
+      last_response.should be_ok
+      parsed = JSON.parse(last_response.body)
+      parsed.length.should == 1
+      parsed[0]["channel"].should == "/__status"
+      parsed[0]["data"]["/foo"].should == @bus.last_id("/foo")
+    end
   end
 
   describe "thin async" do
@@ -376,6 +386,20 @@ describe MessageBus::Rack::Middleware do
 
       parsed = JSON.parse(last_response.body)
       parsed.length.should == 1
+    end
+
+    it "should support json post data" do
+
+      @bus.publish('foo', 'bar')
+
+      header "Content-Type", "application/json"
+      post "/message-bus/ABCD", { '/foo' => -1}.to_json
+      last_response.should be_ok
+      parsed = JSON.parse(last_response.body)
+      parsed.length.should == 1
+      parsed[0]["channel"].should == "/__status"
+      parsed[0]["data"]["/foo"].should ==@bus.last_id("/foo")
+
     end
   end
 


### PR DESCRIPTION
This lets us to make POST with "Content-Type: application/json" and json data. I'm not quite sure what would be the best way to test it cleanly, so I'll be happy to hear your thoughts @SamSaffron.
btw thanks for great gems!