### PR TITLE
Send flush message to JS when position is ahead

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -60,16 +60,15 @@ window.MessageBus = (function() {
     var gotData = false;
     if (!messages) return false; // server unexpectedly closed connection
 
-    $.each(messages,function(_,message) {
+    $.each(messages, function(_,message) {
       gotData = true;
-      $.each(callbacks, function(_,callback) {
+      $.each(callbacks, function(_, callback) {
         if (callback.channel === message.channel) {
           callback.last_id = message.message_id;
           try {
             callback.func(message.data);
-          }
-          catch(e){
-            if(console.log) {
+          } catch(e) {
+            if (console.log) {
               console.log("MESSAGE BUS FAIL: callback " + callback.channel +  " caused exception " + e.message);
             }
           }
@@ -78,6 +77,9 @@ window.MessageBus = (function() {
           if (message.data[callback.channel] !== undefined) {
             callback.last_id = message.data[callback.channel];
           }
+        }
+        if (message.channel === "/__flush") {
+          callback.last_id = -1;
         }
       });
     });

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -89,7 +89,7 @@ class MessageBus::Rack::Middleware
       client.subscribe(k, v)
     end
 
-    backlog = client.backlog
+    backlog = client.backlog(allow_flush: true)
     headers = {}
 
     headers["Cache-Control"] = "must-revalidate, private, max-age=0"

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -29,6 +29,43 @@ describe MessageBus::Client do
       log[0].data.should == 'world'
     end
 
+    it "should provide positions if client subscribes at -1" do
+      10.times do
+        @bus.publish('/hello', 'world')
+      end
+      @bus.publish('/shorter', 'channel')
+
+      @client.subscribe('/hello', '-1')
+      @client.subscribe('/shorter', '-1')
+
+      log = @client.backlog(allow_flush: true)
+
+      log.length.should == 1
+      log[0].channel.should == '/__status'
+      log[0].data.should == {
+          '/hello' => 10,
+          '/shorter' => 1
+      }
+    end
+
+    it "should deliver a flush message if the client is ahead" do
+      @bus.publish('/hello', 'world')
+      position = @bus.last_id('/hello')
+
+      @client.subscribe('/no_messages', nil)
+      @client.subscribe('/hello', 100)
+
+      log = @client.backlog(allow_flush: true)
+
+      log.length.should == 2
+      log[0].channel.should == '/__flush'
+      log[1].channel.should == '/__status'
+      log[1].data.should == {
+          '/no_messages' => 0,
+          '/hello' => 1
+      }
+    end
+
     it "allows only client_id in list if message contains client_ids" do
       @message = MessageBus::Message.new(1, 2, '/test', 'hello')
       @message.client_ids = ["1","2"]


### PR DESCRIPTION
In certain circumstances, a JS client can get channel positions that are
ahead of the message bus. When this happens, the client will not recieve
any more messages until the page is refreshed. This patch fixes that by:
- (middleware) delivering a message on the __flush channel when the
  condition is detected
- (client) resetting all subscriptions to -1 when the __flush message
  is recieved

Note: The 'ahead' condition happens when the Redis DB is flushed.
Although this is not a common operation, flush-resiliency is a desirable
property of many applications using Redis; this change improves the
flush resiliency of MessageBus from "new messages will be lost for an
indeterminate period of time" to "all old messages are lost, plus those
that happen until the client next polls".
