### PR TITLE
Explicitly say that message-bus can be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ JavaScript can listen on any channel (and receive notification via polling or lo
 ```
 Note, the message-bus.js file is located in the assets folder.
 
+**Rails**
+```javascript
+//= require message-bus
+```
+
 ```javascript
 MessageBus.start(); // call once at startup
 


### PR DESCRIPTION
So people know if you can include message-bus via asset pipeline.