### PR TITLE
Port the test suite to MiniTest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rspec'
-  gem 'redis'
+  gem 'minitest'
   gem 'rake'
-  gem 'rbtrace'
-  gem 'guard-rspec'
-  gem 'rb-inotify', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
-  gem 'rack'
   gem 'http_parser.rb'
   gem 'thin'
   gem 'rack-test', require: 'rack/test'

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ If you are looking to contribute to this project here are some ideas
 - Build an in-memory storage backend to ease testing and for very simple deployments
 - Build a PostgreSQL backend using NOTIFY and LISTEN
 - Improve general documentation
-- Port the test suite to MiniTest
 - Make MessageBus a nice website
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'rake/testtask'
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'bundler/setup'
@@ -7,8 +8,7 @@ Bundler.require(:default, :test)
 
 task :default => [:spec]
 
-require 'rspec/core'
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec) do |spec|
-    spec.pattern = FileList['spec/**/*_spec.rb']
+Rake::TestTask.new do |t|
+  t.name = :spec
+  t.pattern = 'spec/**/*_spec.rb'
 end

--- a/spec/lib/message_bus/assets/asset_encoding_spec.rb
+++ b/spec/lib/message_bus/assets/asset_encoding_spec.rb
@@ -1,10 +1,11 @@
+require_relative '../../../spec_helper'
 asset_directory = File.expand_path('../../../../../assets', __FILE__)
 asset_file_paths = Dir.glob(File.join(asset_directory, 'message-bus.js'))
 asset_file_names = asset_file_paths.map{|e| File.basename(e) }
 
 describe asset_file_names do
   it 'should contain .js files' do
-    expect(asset_file_names).to include('message-bus.js')
+    asset_file_names.must_include('message-bus.js')
   end
 end
 
@@ -12,8 +13,7 @@ asset_file_paths.each do | path |
   describe "Asset file #{File.basename(path).inspect}" do
     it 'should be encodable as UTF8' do
       binary_data = File.open(path, 'rb'){|f| f.read }
-      encode_block = -> { binary_data.encode(Encoding::UTF_8) }
-      expect(encode_block).not_to raise_error
+      binary_data.encode(Encoding::UTF_8)
     end
   end
 end

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../../spec_helper'
 require 'message_bus'
 
 describe MessageBus::Client do
@@ -60,36 +60,36 @@ describe MessageBus::Client do
 
       status, headers, chunks = http_parse(lines)
 
-      headers["Content-Type"].should == "text/plain; charset=utf-8"
-      status.should == "200"
-      chunks.length.should == 2
+      headers["Content-Type"].must_equal "text/plain; charset=utf-8"
+      status.must_equal "200"
+      chunks.length.must_equal 2
 
       chunk1 = parse_chunk(chunks[0])
-      chunk1.length.should == 1
-      chunk1.first["data"].should == 'test'
+      chunk1.length.must_equal 1
+      chunk1.first["data"].must_equal 'test'
 
       chunk2 = parse_chunk(chunks[1])
-      chunk2.length.should == 1
-      chunk2.first["data"].should == "a|\r\n|\r\n|b"
+      chunk2.length.must_equal 1
+      chunk2.first["data"].must_equal "a|\r\n|\r\n|b"
 
       @client << MessageBus::Message.new(3, 3, '/test', 'test3')
       @client.close
 
       data = r.read
 
-      data[-5..-1].should == "0\r\n\r\n"
+      data[-5..-1].must_equal "0\r\n\r\n"
 
       _,_,chunks = http_parse("HTTP/1.1 200 OK\r\n\r\n" << data)
 
-      chunks.length.should == 2
+      chunks.length.must_equal 2
 
       chunk1 = parse_chunk(chunks[0])
-      chunk1.length.should == 1
-      chunk1.first["data"].should == 'test3'
+      chunk1.length.must_equal 1
+      chunk1.first["data"].must_equal 'test3'
 
       # end with []
       chunk2 = parse_chunk(chunks[1])
-      chunk2.length.should == 0
+      chunk2.length.must_equal 0
 
     end
 
@@ -99,7 +99,7 @@ describe MessageBus::Client do
       @client.subscribe('/hello', nil)
       @bus.publish '/hello', 'world'
       log = @client.backlog
-      log.length.should == 0
+      log.length.must_equal 0
     end
 
     it "does not bleed status accross sites" do
@@ -108,41 +108,41 @@ describe MessageBus::Client do
       @client.subscribe('/hello', -1)
       @bus.publish '/hello', 'world'
       log = @client.backlog
-      log[0].data.should == {"/hello" => 0}
+      log[0].data.must_equal("/hello" => 0)
     end
 
     it "provides status" do
       @client.subscribe('/hello', -1)
       log = @client.backlog
-      log.length.should == 1
-      log[0].data.should == {"/hello" => 0}
+      log.length.must_equal 1
+      log[0].data.must_equal("/hello" => 0)
     end
 
     it "should provide a list of subscriptions" do
       @client.subscribe('/hello', nil)
-      @client.subscriptions['/hello'].should_not be_nil
+      @client.subscriptions['/hello'].wont_equal nil
     end
 
     it "should provide backlog for subscribed channel" do
       @client.subscribe('/hello', nil)
       @bus.publish '/hello', 'world'
       log = @client.backlog
-      log.length.should == 1
-      log[0].channel.should == '/hello'
-      log[0].data.should == 'world'
+      log.length.must_equal 1
+      log[0].channel.must_equal '/hello'
+      log[0].data.must_equal 'world'
     end
 
     it "allows only client_id in list if message contains client_ids" do
       @message = MessageBus::Message.new(1, 2, '/test', 'hello')
       @message.client_ids = ["1","2"]
       @client.client_id = "2"
-      @client.allowed?(@message).should == true
+      @client.allowed?(@message).must_equal true
 
       @client.client_id = "3"
-      @client.allowed?(@message).should == false
+      @client.allowed?(@message).must_equal false
     end
 
-    context "targetted at group" do
+    describe "targetted at group" do
       before do
         @message = MessageBus::Message.new(1,2,'/test', 'hello')
         @message.group_ids = [1,2,3]
@@ -150,18 +150,18 @@ describe MessageBus::Client do
 
       it "denies users that are not members of group" do
         @client.group_ids = [77,0,10]
-        @client.allowed?(@message).should == false
+        @client.allowed?(@message).must_equal false
       end
 
       it "allows users that are members of group" do
         @client.group_ids = [1,2,3]
-        @client.allowed?(@message).should == true
+        @client.allowed?(@message).must_equal true
       end
 
       it "allows all users if groups not set" do
         @message.group_ids = nil
         @client.group_ids = [77,0,10]
-        @client.allowed?(@message).should == true
+        @client.allowed?(@message).must_equal true
       end
 
     end

--- a/spec/lib/message_bus/multi_process_spec.rb
+++ b/spec/lib/message_bus/multi_process_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../../spec_helper'
 require 'message_bus'
 
 describe MessageBus::Redis::ReliablePubSub do
@@ -44,7 +44,7 @@ describe MessageBus::Redis::ReliablePubSub do
 
       # p responses.group_by(&:data).map{|k,v|[k, v.count]}
       # p responses.group_by(&:global_id).map{|k,v|[k, v.count]}
-      responses.count.should == 100
+      responses.count.must_equal 100
     ensure
       if pids
         pids.each do |pid|

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-require 'spec_helper'
+require_relative '../../../spec_helper'
 require 'message_bus'
 require 'rack/test'
 
@@ -31,24 +31,26 @@ describe MessageBus::Rack::Middleware do
     @async_middleware
   end
 
-  shared_examples "long polling" do
+  module LongPolling
+    extend Minitest::Spec::DSL
+    
     before do
       @bus.long_polling_enabled = true
     end
 
     it "should respond right away if dlp=t" do
       post "/message-bus/ABC?dlp=t", '/foo1' => 0
-      @async_middleware.in_async?.should == false
-      last_response.should be_ok
+      @async_middleware.in_async?.must_equal false
+      last_response.ok?.must_equal true
     end
 
     it "should respond right away to long polls that are polling on -1 with the last_id" do
       post "/message-bus/ABC", '/foo' => -1
-      last_response.should be_ok
+      last_response.ok?.must_equal true
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
-      parsed[0]["channel"].should == "/__status"
-      parsed[0]["data"]["/foo"].should == @bus.last_id("/foo")
+      parsed.length.must_equal 1
+      parsed[0]["channel"].must_equal "/__status"
+      parsed[0]["data"]["/foo"].must_equal @bus.last_id("/foo")
     end
 
     it "should respond to long polls when data is available" do
@@ -66,12 +68,12 @@ describe MessageBus::Rack::Middleware do
 
       post "/message-bus/ABC", '/foo' => nil
 
-      last_response.should be_ok
+      last_response.ok?.must_equal true
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
-      parsed[0]["data"].should == "םוֹלשָׁ"
+      parsed.length.must_equal 1
+      parsed[0]["data"].must_equal "םוֹלשָׁ"
 
-      last_response.headers["FOO"].should == "BAR"
+      last_response.headers["FOO"].must_equal "BAR"
     end
 
     it "should timeout within its alloted slot" do
@@ -80,7 +82,7 @@ describe MessageBus::Rack::Middleware do
         s = Time.now.to_f * 1000
         post "/message-bus/ABC", '/foo' => nil
         # allow for some jitter
-        (Time.now.to_f * 1000 - s).should < 50
+        (Time.now.to_f * 1000 - s).must_be :<, 50
       ensure
         @bus.long_polling_interval = 5000
       end
@@ -91,7 +93,8 @@ describe MessageBus::Rack::Middleware do
     before do
       @async_middleware.simulate_thin_async
     end
-    it_behaves_like "long polling"
+
+    include LongPolling
   end
 
   describe "hijack" do
@@ -99,27 +102,28 @@ describe MessageBus::Rack::Middleware do
       @async_middleware.simulate_hijack
       @bus.rack_hijack_enabled = true
     end
-    it_behaves_like "long polling"
+
+    include LongPolling
   end
 
   describe "diagnostics" do
 
     it "should return a 403 if a user attempts to get at the _diagnostics path" do
       get "/message-bus/_diagnostics"
-      last_response.status.should == 403
+      last_response.status.must_equal 403
     end
 
     it "should get a 200 with html for an authorized user" do
-      @bus.stub(:is_admin_lookup).and_return(lambda{|env| true })
+      def @bus.is_admin_lookup; proc{|_| true} end
       get "/message-bus/_diagnostics"
-      last_response.status.should == 200
+      last_response.status.must_equal 200
     end
 
     it "should get the script it asks for" do
-      @bus.stub(:is_admin_lookup).and_return(lambda{|env| true })
+      def @bus.is_admin_lookup; proc{|_| true} end
       get "/message-bus/_diagnostics/assets/message-bus.js"
-      last_response.status.should == 200
-      last_response.content_type.should == "text/javascript;"
+      last_response.status.must_equal 200
+      last_response.content_type.must_equal "text/javascript;"
     end
 
   end
@@ -142,7 +146,7 @@ describe MessageBus::Rack::Middleware do
         '/bar' => nil
       }
 
-      last_response.headers["FOO"].should == "BAR"
+      last_response.headers["FOO"].must_equal "BAR"
     end
 
     it "should respond with a 200 to a subscribe" do
@@ -153,7 +157,7 @@ describe MessageBus::Rack::Middleware do
         '/foo' => nil,
         '/bar' => nil
       }
-      last_response.should be_ok
+      last_response.ok?.must_equal true
     end
 
     it "should correctly understand that -1 means stuff from now onwards" do
@@ -163,11 +167,11 @@ describe MessageBus::Rack::Middleware do
       post "/message-bus/ABCD", {
         '/foo' => -1
       }
-      last_response.should be_ok
+      last_response.ok?.must_equal true
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
-      parsed[0]["channel"].should == "/__status"
-      parsed[0]["data"]["/foo"].should ==@bus.last_id("/foo")
+      parsed.length.must_equal 1
+      parsed[0]["channel"].must_equal "/__status"
+      parsed[0]["data"]["/foo"].must_equal@bus.last_id("/foo")
 
     end
 
@@ -184,9 +188,9 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 2
-      parsed[0]["data"].should == "barbs"
-      parsed[1]["data"].should == "borbs"
+      parsed.length.must_equal 2
+      parsed[0]["data"].must_equal "barbs"
+      parsed[1]["data"].must_equal "borbs"
     end
 
     it "should have no cross talk" do
@@ -205,7 +209,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 0
+      parsed.length.must_equal 0
 
     end
 
@@ -223,7 +227,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
+      parsed.length.must_equal 1
     end
 
     it "should not get consumed messages" do
@@ -236,7 +240,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 0
+      parsed.length.must_equal 0
     end
 
     it "should filter by user correctly" do
@@ -251,7 +255,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 0
+      parsed.length.must_equal 0
 
       @bus.user_id_lookup do |env|
         1
@@ -262,7 +266,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
+      parsed.length.must_equal 1
     end
 
     it "should filter by group correctly" do
@@ -277,7 +281,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 0
+      parsed.length.must_equal 0
 
       @bus.group_ids_lookup do |env|
         [1,7,4,100]
@@ -288,7 +292,7 @@ describe MessageBus::Rack::Middleware do
       }
 
       parsed = JSON.parse(last_response.body)
-      parsed.length.should == 1
+      parsed.length.must_equal 1
     end
   end
 

--- a/spec/lib/message_bus/redis/reliable_pub_sub_spec.rb
+++ b/spec/lib/message_bus/redis/reliable_pub_sub_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../../../spec_helper'
 require 'message_bus'
 
 describe MessageBus::Redis::ReliablePubSub do
@@ -12,7 +12,7 @@ describe MessageBus::Redis::ReliablePubSub do
     @bus.reset!
   end
 
-  context "readonly" do
+  describe "readonly" do
 
     after do
       @bus.pub_redis.slaveof "no", "one"
@@ -27,13 +27,13 @@ describe MessageBus::Redis::ReliablePubSub do
 
       3.times do
         result = @bus.publish "/foo", "bar"
-        result.should == nil
+        result.must_equal nil
       end
 
       @bus.pub_redis.slaveof "no", "one"
       sleep 0.01
 
-      @bus.backlog("/foo", 0).map(&:data).should == ["bar","bar"]
+      @bus.backlog("/foo", 0).map(&:data).must_equal ["bar","bar"]
 
     end
   end
@@ -41,22 +41,22 @@ describe MessageBus::Redis::ReliablePubSub do
   it "can set backlog age" do
     @bus.max_backlog_age = 100
     @bus.publish "/foo", "bar"
-    @bus.pub_redis.ttl(@bus.backlog_key("/foo")).should be <= 100
-    @bus.pub_redis.ttl(@bus.backlog_key("/foo")).should be > 0
+    @bus.pub_redis.ttl(@bus.backlog_key("/foo")).must_be :<=, 100
+    @bus.pub_redis.ttl(@bus.backlog_key("/foo")).must_be :>, 0
   end
 
   it "should be able to access the backlog" do
     @bus.publish "/foo", "bar"
     @bus.publish "/foo", "baz"
 
-    @bus.backlog("/foo", 0).to_a.should == [
+    @bus.backlog("/foo", 0).to_a.must_equal [
       MessageBus::Message.new(1,1,'/foo','bar'),
       MessageBus::Message.new(2,2,'/foo','baz')
     ]
   end
 
   it "should initialize with max_backlog_size" do
-    MessageBus::Redis::ReliablePubSub.new({},2000).max_backlog_size.should == 2000
+    MessageBus::Redis::ReliablePubSub.new({},2000).max_backlog_size.must_equal 2000
   end
 
   it "should truncate channels correctly" do
@@ -65,7 +65,7 @@ describe MessageBus::Redis::ReliablePubSub do
       @bus.publish "/foo", t.to_s
     end
 
-    @bus.backlog("/foo").to_a.should == [
+    @bus.backlog("/foo").to_a.must_equal [
       MessageBus::Message.new(3,3,'/foo','2'),
       MessageBus::Message.new(4,4,'/foo','3'),
     ]
@@ -77,14 +77,14 @@ describe MessageBus::Redis::ReliablePubSub do
     @bus.publish "/bar", "2"
     @bus.publish "/baz", "3"
 
-    @bus.global_backlog.length.should == 2
+    @bus.global_backlog.length.must_equal 2
   end
 
   it "should be able to grab a message by id" do
     id1 = @bus.publish "/foo", "bar"
     id2 = @bus.publish "/foo", "baz"
-    @bus.get_message("/foo", id2).should == MessageBus::Message.new(2, 2, "/foo", "baz")
-    @bus.get_message("/foo", id1).should == MessageBus::Message.new(1, 1, "/foo", "bar")
+    @bus.get_message("/foo", id2).must_equal MessageBus::Message.new(2, 2, "/foo", "baz")
+    @bus.get_message("/foo", id1).must_equal MessageBus::Message.new(1, 1, "/foo", "bar")
   end
 
   it "should be able to access the global backlog" do
@@ -93,7 +93,7 @@ describe MessageBus::Redis::ReliablePubSub do
     @bus.publish "/foo", "baz"
     @bus.publish "/hello", "planet"
 
-    @bus.global_backlog.to_a.should == [
+    @bus.global_backlog.to_a.must_equal [
       MessageBus::Message.new(1, 1, "/foo", "bar"),
       MessageBus::Message.new(2, 1, "/hello", "world"),
       MessageBus::Message.new(3, 2, "/foo", "baz"),
@@ -108,7 +108,7 @@ describe MessageBus::Redis::ReliablePubSub do
     @bus.publish "/bar", "a"
     @bus.publish "/bar", "b"
 
-    @bus.global_backlog.to_a.should == [
+    @bus.global_backlog.to_a.must_equal [
       MessageBus::Message.new(2, 2, "/foo", "b"),
       MessageBus::Message.new(4, 2, "/bar", "b")
     ]
@@ -148,13 +148,13 @@ describe MessageBus::Redis::ReliablePubSub do
 
     t.kill
 
-    got.length.should == 3
-    got.map{|m| m.data}.should == ["1","2","3"]
+    got.length.must_equal 3
+    got.map{|m| m.data}.must_equal ["1","2","3"]
   end
 
   it "should be able to encode and decode messages properly" do
     m = MessageBus::Message.new 1,2,'||','||'
-    MessageBus::Message.decode(m.encode).should == m
+    MessageBus::Message.decode(m.encode).must_equal m
   end
 
   it "should handle subscribe on single channel, with recovery" do
@@ -176,7 +176,7 @@ describe MessageBus::Redis::ReliablePubSub do
 
     t.kill
 
-    got.map{|m| m.data}.should == ["1","3"]
+    got.map{|m| m.data}.must_equal ["1","3"]
   end
 
   it "should not get backlog if subscribe is called without params" do
@@ -201,13 +201,13 @@ describe MessageBus::Redis::ReliablePubSub do
 
     t.kill
 
-    got.map{|m| m.data}.should == ["2"]
+    got.map{|m| m.data}.must_equal ["2"]
   end
 
   it "should allow us to get last id on a channel" do
-    @bus.last_id("/foo").should == 0
+    @bus.last_id("/foo").must_equal 0
     @bus.publish("/foo", "1")
-    @bus.last_id("/foo").should == 1
+    @bus.last_id("/foo").must_equal 1
   end
 
 end

--- a/spec/lib/message_bus/timer_thread_spec.rb
+++ b/spec/lib/message_bus/timer_thread_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../../spec_helper'
 require 'message_bus/timer_thread'
 
 describe MessageBus::TimerThread do
@@ -13,7 +13,7 @@ describe MessageBus::TimerThread do
   it "allows you to queue every jobs" do
     i = 0
     m = Mutex.new
-    every = @timer.every(0.001){m.synchronize{i += 1}}
+    every = @timer.every(0.001){m.synchronize{i += 1 if i < 3}}
     # allow lots of time, cause in test mode stuff can be slow
     wait_for(1000) do
       m.synchronize do
@@ -22,14 +22,14 @@ describe MessageBus::TimerThread do
       end
     end
     sleep 0.002
-    i.should == 3
+    i.must_equal 3
   end
 
   it "allows you to cancel timers" do
     success = true
     @timer.queue(0.005){success=false}.cancel
     sleep(0.006)
-    success.should == true
+    success.must_equal true
   end
 
   it "queues jobs in the correct order" do
@@ -45,7 +45,7 @@ describe MessageBus::TimerThread do
       4 == results.length
     }
 
-    results.should == [0,1,2,3]
+    results.must_equal [0,1,2,3]
   end
 
   it "should call the error callback if something goes wrong" do
@@ -67,7 +67,7 @@ describe MessageBus::TimerThread do
       error
     end
 
-    error.class.should == NameError
+    error.class.must_equal NameError
   end
 
 end

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../spec_helper'
 require 'message_bus'
 require 'redis'
 
@@ -29,7 +29,7 @@ describe MessageBus do
 
     wait_for(2000){ client_ids}
 
-    client_ids.should == ['a', 'b']
+    client_ids.must_equal ['a', 'b']
 
   end
 
@@ -49,7 +49,7 @@ describe MessageBus do
 
     wait_for(2000){ data["yeager"]}
 
-    data["yeager"].should == true
+    data["yeager"].must_equal true
 
   end
 
@@ -61,7 +61,7 @@ describe MessageBus do
     @bus.publish("/chuck", {:norris => true})
     wait_for(2000){ data }
 
-    data["norris"].should == true
+    data["norris"].must_equal true
   end
 
   it "should get a message if it subscribes to it" do
@@ -78,10 +78,10 @@ describe MessageBus do
 
     wait_for(2000){data}
 
-    data.should == 'norris'
-    site_id.should == 'magic'
-    channel.should == '/chuck'
-    user_ids.should == [1,2,3]
+    data.must_equal 'norris'
+    site_id.must_equal 'magic'
+    channel.must_equal '/chuck'
+    user_ids.must_equal [1,2,3]
 
   end
 
@@ -99,9 +99,9 @@ describe MessageBus do
 
     wait_for(2000){data}
 
-    data.should == 'norris'
-    site_id.should == 'magic'
-    channel.should == '/chuck'
+    data.must_equal 'norris'
+    site_id.must_equal 'magic'
+    channel.must_equal '/chuck'
 
   end
 
@@ -112,7 +112,7 @@ describe MessageBus do
 
     r = @bus.backlog("/chuck", id)
 
-    r.map{|i| i.data}.to_a.should == ['foo', 'bar']
+    r.map{|i| i.data}.to_a.must_equal ['foo', 'bar']
   end
 
   it "should correctly get full backlog of a channel" do
@@ -120,18 +120,18 @@ describe MessageBus do
     @bus.publish("/chuck", "foo")
     @bus.publish("/chuckles", "bar")
 
-    @bus.backlog("/chuck").map{|i| i.data}.to_a.should == ['norris', 'foo']
+    @bus.backlog("/chuck").map{|i| i.data}.to_a.must_equal ['norris', 'foo']
 
   end
 
   it "allows you to look up last_message" do
     @bus.publish("/bob", "dylan")
     @bus.publish("/bob", "marley")
-    @bus.last_message("/bob").data.should == "marley"
-    @bus.last_message("/nothing").should == nil
+    @bus.last_message("/bob").data.must_equal "marley"
+    @bus.last_message("/nothing").must_equal nil
   end
 
-  context "global subscriptions" do
+  describe "global subscriptions" do
     before do
       seq = 0
       @bus.site_id_lookup do
@@ -141,7 +141,7 @@ describe MessageBus do
 
     it "can get last_message" do
       @bus.publish("/global/test", "test")
-      @bus.last_message("/global/test").data.should == "test"
+      @bus.last_message("/global/test").data.must_equal "test"
     end
 
     it "can subscribe globally" do
@@ -154,7 +154,7 @@ describe MessageBus do
       @bus.publish("/global/test", "test")
       wait_for(1000){ data }
 
-      data.should == "test"
+      data.must_equal "test"
     end
 
     it "can subscribe to channel" do
@@ -167,19 +167,19 @@ describe MessageBus do
       @bus.publish("/global/test", "test")
       wait_for(1000){ data }
 
-      data.should == "test"
+      data.must_equal "test"
     end
 
     it "should exception if publishing restricted messages to user" do
       lambda do
         @bus.publish("/global/test", "test", user_ids: [1])
-      end.should raise_error(MessageBus::InvalidMessage)
+      end.must_raise(MessageBus::InvalidMessage)
     end
 
     it "should exception if publishing restricted messages to group" do
       lambda do
         @bus.publish("/global/test", "test", user_ids: [1])
-      end.should raise_error(MessageBus::InvalidMessage)
+      end.must_raise(MessageBus::InvalidMessage)
     end
 
   end
@@ -198,7 +198,7 @@ describe MessageBus do
       wait_for(2000) { data == "ready" }
       @bus.publish("/hello", "world1")
       wait_for(2000) { data == "got it" }
-      data.should == "got it"
+      data.must_equal "got it"
       Process.wait(child)
     else
       @bus.after_fork

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,9 @@
+$: << File.dirname(__FILE__)
 require 'thin'
 require 'lib/fake_async_middleware'
 
-RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = [:should, :expect]
-  end
-  config.mock_with :rspec do |mocks|
-    mocks.syntax = :should
-  end
-
-  # to debug hanging tests
-  # config.before :each do |x|
-  #   $start = Time.now
-  #   puts "Start: #{x.metadata[:location]}"
-  # end
-  #
-  # config.after :each do |x|
-  #   puts "#{x.metadata[:location]} #{Time.now - $start}"
-  # end
-end
+require 'minitest/autorun'
+require 'minitest/spec'
 
 def wait_for(timeout_milliseconds)
   timeout = (timeout_milliseconds + 0.0) / 1000
@@ -30,5 +15,3 @@ def wait_for(timeout_milliseconds)
   end
   t.join
 end
-
-


### PR DESCRIPTION
This actually uses minitest/spec.  Hopefully that's fine.

This replaces rspec with minitest in the Gemfile, and removes
the redis, rack, rbtrace, guard-rspec, and rb-notify gems from
the Gemfile.  redis and rack in the gemspec and do not need to
be specified twice, guard-rspec seems to be related to rspec,
and rbtrace and rb-inotify don't seem to be needed to run the
tests.

Most of this was done mechanically using the same script I
used for converting Sequel's and all of my other libraries'
specs from rspec to minitest.

I used require_relative in the specs to get the spec_helper.
This should be fine as messagebus doesn't appear to support
ruby 1.8.