### PR TITLE
Support passing channels to Rack middleware via env['message_bus.channels']

### DIFF
--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -84,12 +84,21 @@ class MessageBus::Rack::Middleware
     client = MessageBus::Client.new(message_bus: @bus, client_id: client_id,
                                     user_id: user_id, site_id: site_id, group_ids: group_ids)
 
-    request = Rack::Request.new(env)
-    request.POST.each do |k,v|
-      if k == "__seq".freeze
-        client.seq = v.to_i
-      else
+    if channels = env['message_bus.channels']
+      if seq = env['message_bus.seq']
+        client.seq = seq.to_i
+      end
+      channels.each do |k, v|
         client.subscribe(k, v)
+      end
+    else
+      request = Rack::Request.new(env)
+      request.POST.each do |k,v|
+        if k == "__seq".freeze
+          client.seq = v.to_i
+        else
+          client.subscribe(k, v)
+        end
       end
     end
 


### PR DESCRIPTION
This changes MessageBus::Rack::Middleware to recognize the
'message_bus.channels' env entry as the channels to use for the
request, in preference to creating a new Rack::Request object
and using Rack::Request#POST.

This makes it easier for earlier middleware or request handler to
handle access controls for channels.  Currently, to do so would
require messing with rack.input, which is kind of a pain.

To support setting the client.seq value, that can also be specified
as the 'message_bus.seq' env entry.

There is no change to backwards compatibility if the
'message_bus.channels' env entry is not present.

For an example of how I plan to use this with Roda:
http://pastie.org/pastes/10736290/text