### PR TITLE
Make all specs run with same backend, fix PostgreSQL fork handling

### DIFF
--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -103,25 +103,19 @@ class MessageBus::Postgres::Client
     sync{@listening_on[channel] = obj}
     listener = Listener.new
     yield listener
-    pid = Process.pid
     
     conn = raw_pg_connection
     conn.exec "LISTEN #{channel}"
     listener.do_sub.call
     while listening_on?(channel, obj)
       conn.wait_for_notify(10) do |_,_,payload|
+        break unless listening_on?(channel, obj)
         listener.do_message.call(nil, payload)
       end
-      break if pid != Process.pid
     end
     listener.do_unsub.call
 
-    if pid != Process.pid
-      sync{INHERITED_CONNECTIONS << conn}
-    else
-      conn.exec "UNLISTEN #{channel}"
-    end
-
+    conn.exec "UNLISTEN #{channel}"
     nil
   end
 
@@ -150,7 +144,6 @@ class MessageBus::Postgres::Client
     if current_pid != @pid
       @pid = current_pid
       sync do
-        @listening_on.clear
         INHERITED_CONNECTIONS.concat(@available)
         @available.clear
       end

--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -133,7 +133,7 @@ class MessageBus::Postgres::Client
   end
 
   def create_table(conn)
-    conn.exec 'CREATE TABLE message_bus (id bigserial PRIMARY KEY, channel text NOT NULL, value text NOT NULL, added_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL)'
+    conn.exec 'CREATE TABLE message_bus (id bigserial PRIMARY KEY, channel text NOT NULL, value text NOT NULL CHECK (octet_length(value) >= 2), added_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL)'
     conn.exec 'CREATE INDEX table_channel_id_index ON message_bus (channel, id)'
     conn.exec 'CREATE INDEX table_added_at_index ON message_bus (added_at)'
     nil

--- a/spec/lib/message_bus/backends/postgres_spec.rb
+++ b/spec/lib/message_bus/backends/postgres_spec.rb
@@ -56,20 +56,20 @@ describe PUB_SUB_CLASS do
   it "should truncate channels correctly" do
     @bus.max_backlog_size = 2
     4.times do |t|
-      @bus.publish "/foo", t.to_s
+      @bus.publish "/foo", "1#{t}"
     end
 
     @bus.backlog("/foo").to_a.must_equal [
-      MessageBus::Message.new(3,3,'/foo','2'),
-      MessageBus::Message.new(4,4,'/foo','3'),
+      MessageBus::Message.new(3,3,'/foo','12'),
+      MessageBus::Message.new(4,4,'/foo','13'),
     ]
   end
 
   it "should truncate global backlog correctly" do
     @bus.max_global_backlog_size = 2
-    @bus.publish "/foo", "1"
-    @bus.publish "/bar", "2"
-    @bus.publish "/baz", "3"
+    @bus.publish "/foo", "11"
+    @bus.publish "/bar", "21"
+    @bus.publish "/baz", "31"
 
     @bus.global_backlog.length.must_equal 2
   end
@@ -97,14 +97,14 @@ describe PUB_SUB_CLASS do
 
   it "should correctly omit dropped messages from the global backlog" do
     @bus.max_backlog_size = 1
-    @bus.publish "/foo", "a"
-    @bus.publish "/foo", "b"
-    @bus.publish "/bar", "a"
-    @bus.publish "/bar", "b"
+    @bus.publish "/foo", "a1"
+    @bus.publish "/foo", "b1"
+    @bus.publish "/bar", "a1"
+    @bus.publish "/bar", "b1"
 
     @bus.global_backlog.to_a.must_equal [
-      MessageBus::Message.new(2, 2, "/foo", "b"),
-      MessageBus::Message.new(4, 4, "/bar", "b")
+      MessageBus::Message.new(2, 2, "/foo", "b1"),
+      MessageBus::Message.new(4, 4, "/bar", "b1")
     ]
   end
 
@@ -112,9 +112,9 @@ describe PUB_SUB_CLASS do
     threads = []
     4.times do
       threads << Thread.new do
-        bus = new_test_bus
+        bus = @bus
         25.times {
-          bus.publish "/foo", "."
+          bus.publish "/foo", ".."
         }
       end
     end
@@ -124,17 +124,17 @@ describe PUB_SUB_CLASS do
   end
 
   it "should be able to subscribe globally with recovery" do
-    @bus.publish("/foo", "1")
-    @bus.publish("/bar", "2")
+    @bus.publish("/foo", "11")
+    @bus.publish("/bar", "12")
     got = []
 
     t = Thread.new do
-      new_test_bus.global_subscribe(0) do |msg|
+      @bus.global_subscribe(0) do |msg|
         got << msg
       end
     end
 
-    @bus.publish("/bar", "3")
+    @bus.publish("/bar", "13")
 
     wait_for(100) do
       got.length == 3
@@ -143,7 +143,7 @@ describe PUB_SUB_CLASS do
     t.kill
 
     got.length.must_equal 3
-    got.map{|m| m.data}.must_equal ["1","2","3"]
+    got.map{|m| m.data}.must_equal ["11","12","13"]
   end
 
   it "should be able to encode and decode messages properly" do
@@ -152,17 +152,17 @@ describe PUB_SUB_CLASS do
   end
 
   it "should handle subscribe on single channel, with recovery" do
-    @bus.publish("/foo", "1")
-    @bus.publish("/bar", "2")
+    @bus.publish("/foo", "11")
+    @bus.publish("/bar", "12")
     got = []
 
     t = Thread.new do
-      new_test_bus.subscribe("/foo",0) do |msg|
+      @bus.subscribe("/foo",0) do |msg|
         got << msg
       end
     end
 
-    @bus.publish("/foo", "3")
+    @bus.publish("/foo", "13")
 
     wait_for(100) do
       got.length == 2
@@ -170,15 +170,15 @@ describe PUB_SUB_CLASS do
 
     t.kill
 
-    got.map{|m| m.data}.must_equal ["1","3"]
+    got.map{|m| m.data}.must_equal ["11","13"]
   end
 
   it "should not get backlog if subscribe is called without params" do
-    @bus.publish("/foo", "1")
+    @bus.publish("/foo", "11")
     got = []
 
     t = Thread.new do
-      new_test_bus.subscribe("/foo") do |msg|
+      @bus.subscribe("/foo") do |msg|
         got << msg
       end
     end
@@ -187,7 +187,7 @@ describe PUB_SUB_CLASS do
     #   I thought about adding a subscribed callback, but outside of testing it matters less
     sleep 0.05
 
-    @bus.publish("/foo", "2")
+    @bus.publish("/foo", "12")
 
     wait_for(100) do
       got.length == 1
@@ -195,12 +195,12 @@ describe PUB_SUB_CLASS do
 
     t.kill
 
-    got.map{|m| m.data}.must_equal ["2"]
+    got.map{|m| m.data}.must_equal ["12"]
   end
 
   it "should allow us to get last id on a channel" do
     @bus.last_id("/foo").must_equal 0
-    @bus.publish("/foo", "1")
+    @bus.publish("/foo", "11")
     @bus.last_id("/foo").must_equal 1
   end
 

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -7,7 +7,7 @@ describe MessageBus::Client do
 
     before do
       @bus = MessageBus::Instance.new
-      @bus.redis_config = MESSAGE_BUS_CONFIG
+      @bus.configure(MESSAGE_BUS_CONFIG)
       @client = MessageBus::Client.new client_id: 'abc', message_bus: @bus
     end
 

--- a/spec/lib/message_bus/multi_process_spec.rb
+++ b/spec/lib/message_bus/multi_process_spec.rb
@@ -44,7 +44,7 @@ describe PUB_SUB_CLASS do
       new_bus.reset!
       begin
         pids = (1..10).map{spawn_child}
-        expected_responses = pids.map{|x| (0...10).map{|i| "#{i}-#{x}"}}.flatten
+        expected_responses = pids.map{|x| (0...10).map{|i| "0#{i}-#{x}"}}.flatten
         unexpected_responses = []
         bus = new_bus
         t = Thread.new do
@@ -56,7 +56,7 @@ describe PUB_SUB_CLASS do
             end
           end
         end
-        10.times{|i| bus.publish("/echo", i.to_s)}
+        10.times{|i| bus.publish("/echo", "0#{i}")}
         wait_for 4000 do
           expected_responses.empty?
         end

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -23,9 +23,10 @@ describe MessageBus::Rack::Middleware do
 
     @async_middleware = builder.to_app
     @message_bus_middleware = @async_middleware.app
+    @bus.reset!
   end
 
-  after do |x|
+  after do
     @message_bus_middleware.stop_listener
     @bus.reset!
     @bus.destroy

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -10,7 +10,7 @@ describe MessageBus::Rack::Middleware do
 
   before do
     bus = @bus = MessageBus::Instance.new
-    @bus.redis_config = MESSAGE_BUS_CONFIG
+    @bus.configure(MESSAGE_BUS_CONFIG)
     @bus.long_polling_enabled = false
 
     e_m = extra_middleware

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -43,7 +43,7 @@ describe MessageBus do
     @bus.publish("/chuck", {:norris => true})
     @bus.publish("/chuck", {:norris => true})
 
-    @bus.reliable_pub_sub.pub_redis.flushall
+    @bus.reliable_pub_sub.reset!
 
     @bus.publish("/chuck", {:yeager => true})
 

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -10,7 +10,7 @@ describe MessageBus do
     @bus.site_id_lookup do
       "magic"
     end
-    @bus.redis_config = MESSAGE_BUS_CONFIG
+    @bus.configure(MESSAGE_BUS_CONFIG)
   end
 
   after do


### PR DESCRIPTION
redis_config= was used in the specs, which sets the backend to redis.  This resulted in some of the specs being run on redis even when using `spec_postgres`.  Fix that, then fix a couple issues exposed when all specs run with the postgres backend.  One was a spec issue, one was an issue in the postgres backend related to fork handling.