### PR TITLE
Add memory backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ MessageBus.configure(backend: :postgres, backend_options: {user: 'message_bus', 
 
 The PostgreSQL client message_bus uses is [ruby-pg](https://bitbucket.org/ged/ruby-pg), so you can visit it's repo to see what options you can configure.
 
+### Memory
+
+message_bus also supports an in-memory backend.  This can be used for testing or simple single-process environments that do not require persistence.
+
+```ruby
+MessageBus.configure(backend: :memory)
+```
+
 ### Forking/threading app servers
 
 If you're using a forking or threading app server and you're not getting immediate updates from published messages, you might need to reconnect Redis/PostgreSQL in your app server config:

--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,14 @@ run_spec = proc do |backend|
   end
 end
 
-task :spec => [:spec_redis, :spec_postgres]
+task :spec => [:spec_redis, :spec_postgres, :spec_memory]
 
 task :spec_redis do
   run_spec.call('redis')
+end
+
+task :spec_memory do
+  run_spec.call('memory')
 end
 
 task :spec_postgres do

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -473,7 +473,7 @@ module MessageBus::Implementation
         globals, locals, local_globals, global_globals = nil
 
         @mutex.synchronize do
-          raise MessageBus::BusDestroyed if @destroyed
+          return if @destroyed
           next unless @subscriptions
 
           globals = @subscriptions[nil]

--- a/lib/message_bus/backends/memory.rb
+++ b/lib/message_bus/backends/memory.rb
@@ -1,0 +1,293 @@
+module MessageBus::Memory; end
+
+class MessageBus::Memory::Client
+  class Listener
+    attr_reader :do_sub, :do_unsub, :do_message
+
+    def subscribe(&block)
+      @do_sub = block
+    end
+
+    def unsubscribe(&block)
+      @do_unsub = block
+    end
+
+    def message(&block)
+      @do_message = block
+    end
+  end
+
+  def initialize(config)
+    @mutex = Mutex.new
+    @listeners = []
+    reset!
+  end
+
+  def add(channel, value)
+    listeners = nil
+    id = nil
+    sync do
+      id = @global_id += 1
+      chan(channel) << [id, value]
+      listeners = @listeners.dup
+    end
+    msg = MessageBus::Message.new id, id, channel, value
+    payload = msg.encode
+    listeners.each{|l| l.push(payload)}
+    id
+  end
+
+  def clear_global_backlog(backlog_id, num_to_keep)
+    if backlog_id > num_to_keep
+      oldest = backlog_id - num_to_keep
+      sync do
+        @channels.each_value do |entries|
+          entries.delete_if{|id, _| id <= oldest}
+        end
+      end
+      nil
+    end
+  end
+
+  def clear_channel_backlog(channel, backlog_id, num_to_keep)
+    oldest = backlog_id - num_to_keep
+    sync{chan(channel).delete_if{|id, _| id <= oldest}}
+    nil
+  end
+
+  def backlog(channel, backlog_id)
+    sync{chan(channel).select{|id, _| id > backlog_id}}
+  end
+
+  def global_backlog(backlog_id)
+    sync do
+      @channels.dup.flat_map do |channel, messages|
+        messages.select{|id, _| id > backlog_id}.map{|id, value| [id, channel, value]}
+      end.sort
+    end
+  end
+
+  def get_value(channel, id)
+    sync{chan(channel).find{|i, _| i == id}.last}
+  end
+
+  # Dangerous, drops the message_bus table containing the backlog if it exists.
+  def reset!
+    sync do
+      @global_id = 0
+      @channels = {}
+    end
+  end
+
+  def max_id(channel=nil)
+    if channel
+      sync do
+        if entry = chan(channel).last
+          entry.first
+        end
+      end
+    else
+      sync{@global_id - 1}
+    end || 0
+  end
+
+  def subscribe
+    listener = Listener.new
+    yield listener
+
+    q = Queue.new
+    sync do
+      @listeners << q
+    end
+
+    listener.do_sub.call
+    while msg = q.pop
+      listener.do_message.call(nil, msg)
+    end
+    listener.do_unsub.call
+    sync do
+      @listeners.delete(q)
+    end
+
+    nil
+  end
+
+  def unsubscribe
+    sync{@listeners.each{|l| l.push(nil)}}
+  end
+
+  private
+
+  def chan(channel)
+    @channels[channel] ||= []
+  end
+
+  def sync
+    @mutex.synchronize{yield}
+  end
+end
+
+class MessageBus::Memory::ReliablePubSub
+  attr_reader :subscribed
+  attr_accessor :max_publish_retries, :max_publish_wait, :max_backlog_size,
+                :max_global_backlog_size, :max_in_memory_publish_backlog,
+                :max_backlog_age
+
+  UNSUB_MESSAGE = "$$UNSUBSCRIBE"
+
+  # max_backlog_size is per multiplexed channel
+  def initialize(config = {}, max_backlog_size = 1000)
+    @config = config
+    @max_backlog_size = max_backlog_size
+    @max_global_backlog_size = 2000
+    @max_publish_retries = 10
+    @max_publish_wait = 500 #ms
+    @max_in_memory_publish_backlog = 1000
+    @in_memory_backlog = []
+    @lock = Mutex.new
+    @flush_backlog_thread = nil
+    # after 7 days inactive backlogs will be removed
+    @max_backlog_age = 604800
+    @h = {}
+  end
+
+  def new_connection
+    MessageBus::Memory::Client.new(@config)
+  end
+
+  def backend
+    :memory
+  end
+
+  def after_fork
+    nil
+  end
+
+  def client
+    @client ||= new_connection
+  end
+
+  # use with extreme care, will nuke all of the data
+  def reset!
+    client.reset!
+  end
+
+  def publish(channel, data, queue_in_memory=true)
+    client = self.client
+    backlog_id = client.add(channel, data)
+    client.clear_global_backlog(backlog_id, @max_global_backlog_size)
+    client.clear_channel_backlog(channel, backlog_id, @max_backlog_size)
+
+    backlog_id
+  end
+
+  def last_id(channel)
+    client.max_id(channel)
+  end
+
+  def backlog(channel, last_id = nil)
+    items = client.backlog channel, last_id.to_i
+
+    items.map! do |id, data|
+      MessageBus::Message.new id, id, channel, data
+    end
+  end
+
+  def global_backlog(last_id = nil)
+    last_id = last_id.to_i
+
+    items = client.global_backlog last_id.to_i
+
+    items.map! do |id, channel, data|
+      MessageBus::Message.new id, id, channel, data
+    end
+  end
+
+  def get_message(channel, message_id)
+    if data = client.get_value(channel, message_id)
+      MessageBus::Message.new message_id, message_id, channel, data
+    else
+      nil
+    end
+  end
+
+  def subscribe(channel, last_id = nil)
+    # trivial implementation for now,
+    #   can cut down on connections if we only have one global subscriber
+    raise ArgumentError unless block_given?
+
+    global_subscribe(last_id) do |m|
+      yield m if m.channel == channel
+    end
+  end
+
+  def process_global_backlog(highest_id)
+    if highest_id > client.max_id
+      highest_id = 0
+    end
+
+    global_backlog(highest_id).each do |old|
+      yield old
+      highest_id = old.global_id
+    end
+
+    highest_id
+  end
+
+  def global_unsubscribe
+    client.unsubscribe
+    @subscribed = false
+  end
+
+  def global_subscribe(last_id=nil, &blk)
+    raise ArgumentError unless block_given?
+    highest_id = last_id
+
+    begin
+      client.subscribe do |on|
+        h = {}
+
+        on.subscribe do
+          if highest_id
+            process_global_backlog(highest_id) do |m|
+              h[m.global_id] = true
+              yield m
+            end
+          end
+          @subscribed = true
+        end
+
+        on.unsubscribe do
+          @subscribed = false
+        end
+
+        on.message do |c,m|
+          m = MessageBus::Message.decode m
+
+          # we have 3 options
+          #
+          # 1. message came in the correct order GREAT, just deal with it
+          # 2. message came in the incorrect order COMPLICATED, wait a tiny bit and clear backlog
+          # 3. message came in the incorrect order and is lowest than current highest id, reset
+
+          if h
+            # If already yielded during the clear backlog when subscribing,
+            # don't yield a duplicate copy.
+            unless h.delete(m.global_id)
+              h = nil if h.empty?
+              yield m
+            end
+          else
+            yield m
+          end
+        end
+      end
+    rescue => error
+      MessageBus.logger.warn "#{error} subscribe failed, reconnecting in 1 second. Call stack\n#{error.backtrace.join("\n")}"
+      sleep 1
+      retry
+    end
+  end
+
+  MessageBus::BACKENDS[:memory] = self
+end

--- a/spec/lib/message_bus/backends/postgres_spec.rb
+++ b/spec/lib/message_bus/backends/postgres_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../spec_helper'
 require 'message_bus'
 
-if MESSAGE_BUS_CONFIG[:backend] == :postgres
+if MESSAGE_BUS_CONFIG[:backend] == :postgres || MESSAGE_BUS_CONFIG[:backend] == :memory
 describe PUB_SUB_CLASS do
 
   def new_test_bus

--- a/spec/lib/message_bus/multi_process_spec.rb
+++ b/spec/lib/message_bus/multi_process_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../spec_helper'
 require 'message_bus'
 
+unless MESSAGE_BUS_CONFIG[:backend] == :memory
 describe PUB_SUB_CLASS do
   def self.error!
     @error = true
@@ -82,4 +83,5 @@ describe PUB_SUB_CLASS do
       end
     end
   end
+end
 end

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -184,39 +184,40 @@ describe MessageBus do
 
   end
 
-  it "should support forking properly do" do
-    data = nil
-    @bus.subscribe do |msg|
-      data = msg.data
-    end
-
-    @bus.publish("/hello", "world")
-
-    wait_for(2000){ data }
-
-    if child = Process.fork
-      wait_for(2000) { data == "ready" }
-      @bus.publish("/hello", "world1")
-      wait_for(2000) { data == "got it" }
-      data.must_equal "got it"
-      Process.wait(child)
-    else
-      begin
-        @bus.after_fork
-        @bus.publish("/hello", "ready")
-        wait_for(2000) { data == "world1" }
-        if(data=="world1")
-          @bus.publish("/hello", "got it")
-        end
-
-        $stdout.reopen("/dev/null", "w")
-        $stderr.reopen("/dev/null", "w")
-
-      ensure
-        exit!(0)
+  unless MESSAGE_BUS_CONFIG[:backend] == :memory
+    it "should support forking properly do" do
+      data = nil
+      @bus.subscribe do |msg|
+        data = msg.data
       end
+
+      @bus.publish("/hello", "world")
+
+      wait_for(2000){ data }
+
+      if child = Process.fork
+        wait_for(2000) { data == "ready" }
+        @bus.publish("/hello", "world1")
+        wait_for(2000) { data == "got it" }
+        data.must_equal "got it"
+        Process.wait(child)
+      else
+        begin
+          @bus.after_fork
+          @bus.publish("/hello", "ready")
+          wait_for(2000) { data == "world1" }
+          if(data=="world1")
+            @bus.publish("/hello", "got it")
+          end
+
+          $stdout.reopen("/dev/null", "w")
+          $stderr.reopen("/dev/null", "w")
+
+        ensure
+          exit!(0)
+        end
+      end
+
     end
-
   end
-
 end


### PR DESCRIPTION
The memory backend uses the same specs as the postgres backend,
except it doesn't run the fork or multi_process specs, since
those wouldn't work.

Only change to the lib code is returning instead of raising on
a destoryed bus.  The memory backend is fast enough that it
exposes a race condition in the rack middleware spec causing
warnings but no failures.  I think it's simpler to just
return in this case, as if the bus has been destroyed, you
don't want to keep subscribing.