### PR TITLE
Support :clear_every option on postgres and memory backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ message_bus also supports PostgreSQL as the backend:
 MessageBus.configure(backend: :postgres, backend_options: {user: 'message_bus', dbname: 'message_bus'})
 ```
 
-The PostgreSQL client message_bus uses is [ruby-pg](https://bitbucket.org/ged/ruby-pg), so you can visit it's repo to see what options you can configure.
+The PostgreSQL client message_bus uses is [ruby-pg](https://bitbucket.org/ged/ruby-pg), so you can visit it's repo to see what options you can configure inside `:backend_options`.
+
+A `:clear_every` option is also supported, which only clears the backlogs on every number of requests given.  So if you set `clear_every: 100`, the backlog will only be cleared every 100 requests.  This can improve performance in cases where exact backlog clearing are not required.
 
 ### Memory
 
@@ -229,6 +231,8 @@ message_bus also supports an in-memory backend.  This can be used for testing or
 ```ruby
 MessageBus.configure(backend: :memory)
 ```
+
+The `:clear_every` option supported by the PostgreSQL backend is also supported by the in-memory backend.
 
 ### Forking/threading app servers
 

--- a/lib/message_bus/backends/memory.rb
+++ b/lib/message_bus/backends/memory.rb
@@ -129,9 +129,7 @@ end
 
 class MessageBus::Memory::ReliablePubSub
   attr_reader :subscribed
-  attr_accessor :max_publish_retries, :max_publish_wait, :max_backlog_size,
-                :max_global_backlog_size, :max_in_memory_publish_backlog,
-                :max_backlog_age
+  attr_accessor :max_backlog_size, :max_global_backlog_size, :clear_every
 
   UNSUB_MESSAGE = "$$UNSUBSCRIBE"
 
@@ -140,15 +138,8 @@ class MessageBus::Memory::ReliablePubSub
     @config = config
     @max_backlog_size = max_backlog_size
     @max_global_backlog_size = 2000
-    @max_publish_retries = 10
-    @max_publish_wait = 500 #ms
-    @max_in_memory_publish_backlog = 1000
-    @in_memory_backlog = []
-    @lock = Mutex.new
-    @flush_backlog_thread = nil
     # after 7 days inactive backlogs will be removed
-    @max_backlog_age = 604800
-    @h = {}
+    @clear_every = config[:clear_every] || 1
   end
 
   def new_connection
@@ -175,8 +166,10 @@ class MessageBus::Memory::ReliablePubSub
   def publish(channel, data, queue_in_memory=true)
     client = self.client
     backlog_id = client.add(channel, data)
-    client.clear_global_backlog(backlog_id, @max_global_backlog_size)
-    client.clear_channel_backlog(channel, backlog_id, @max_backlog_size)
+    if backlog_id % clear_every == 0
+      client.clear_global_backlog(backlog_id, @max_global_backlog_size)
+      client.clear_channel_backlog(channel, backlog_id, @max_backlog_size)
+    end
 
     backlog_id
   end

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -10,9 +10,7 @@ require 'redis'
 module MessageBus::Redis; end
 class MessageBus::Redis::ReliablePubSub
   attr_reader :subscribed
-  attr_accessor :max_publish_retries, :max_publish_wait, :max_backlog_size,
-                :max_global_backlog_size, :max_in_memory_publish_backlog,
-                :max_backlog_age
+  attr_accessor :max_backlog_size, :max_global_backlog_size, :max_in_memory_publish_backlog, :max_backlog_age
 
   UNSUB_MESSAGE = "$$UNSUBSCRIBE"
 
@@ -33,8 +31,6 @@ class MessageBus::Redis::ReliablePubSub
     end
     @max_backlog_size = max_backlog_size
     @max_global_backlog_size = 2000
-    @max_publish_retries = 10
-    @max_publish_wait = 500 #ms
     @max_in_memory_publish_backlog = 1000
     @in_memory_backlog = []
     @lock = Mutex.new

--- a/spec/lib/message_bus/backends/postgres_spec.rb
+++ b/spec/lib/message_bus/backends/postgres_spec.rb
@@ -74,6 +74,19 @@ describe PUB_SUB_CLASS do
     @bus.global_backlog.length.must_equal 2
   end
 
+  it "should support clear_every setting" do
+    @bus.clear_every = 5
+    @bus.max_global_backlog_size = 2
+    @bus.publish "/foo", "11"
+    @bus.publish "/bar", "21"
+    @bus.publish "/baz", "31"
+    @bus.publish "/bar", "41"
+    @bus.global_backlog.length.must_equal 4
+
+    @bus.publish "/baz", "51"
+    @bus.global_backlog.length.must_equal 2
+  end
+
   it "should be able to grab a message by id" do
     id1 = @bus.publish "/foo", "bar"
     id2 = @bus.publish "/foo", "baz"


### PR DESCRIPTION
This option will only clear the backlog every x requests,
which can increase performance on the postgres backend
by skipping 2 queries most calls to publish.

This also removes unused options from all backends.