### PR TITLE
Add a noConflict method to remove MessageBus from global namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ backgroundCallbackInterval|60000|Interval to poll when long polling is disabled 
 maxPollInterval|180000|If request to the server start failing, MessageBus will backoff, this is the upper limit of the backoff.
 alwaysLongPoll|false|For debugging you may want to disable the "is browser in background" check and always long-poll
 baseUrl|/|If message bus is mounted in a subdirectory of different domain, you may configure it to perform requests there
-ajax|$.ajax or MessageBus.ajaxImplementation|MessageBus will first attempt to use jQuery and then fallback to a plain XMLHttpRequest version that's contained in the `messsage-bus-ajax.js` file. `messsage-bus-ajax.js` must be loaded before `messsage-bus.js` if jQuery is not present.
+ajax|$.ajax or XMLHttpRequest|MessageBus will first attempt to use jQuery and then fallback to a plain XMLHttpRequest version that's contained in the `messsage-bus-ajax.js` file. `messsage-bus-ajax.js` must be loaded after `messsage-bus.js` for it to be used.
 
 **API**:
 
@@ -191,6 +191,8 @@ ajax|$.ajax or MessageBus.ajaxImplementation|MessageBus will first attempt to us
 `MessageBus.subscribe(channel,func,lastId)` : Subscribe to a channel, optionally you may specify the id of the last message you received in the channel.
 
 `MessageBus.unsubscribe(channel,func)` : Unsubscribe callback from a particular channel
+
+`MessageBus.noConflict()` : Removes MessageBus from the global namespace by replacing it with whatever was present before MessageBus was loaded.  Returns a reference to the MessageBus object.
 
 ## Running tests
 

--- a/assets/message-bus-ajax.js
+++ b/assets/message-bus-ajax.js
@@ -4,11 +4,13 @@
 // Only implements methods & options used by MessageBus
 (function(global, undefined) {
   'use strict';
+  if (!global.MessageBus){
+      throw new Error("MessageBus must be loaded before the ajax adapter");
+  }
 
   var cacheBuster =  Math.random() * 10000 | 0;
-  var MessageBus = global.MessageBus || (global.MessageBus = {});
 
-  MessageBus.ajaxImplementation = function(options){
+  global.MessageBus.ajax = function(options){
     var XHRImpl = global.MessageBus.xhrImplementation || global.XMLHttpRequest;
     var xhr = new XHRImpl();
     xhr.dataType = options.dataType;

--- a/spec/assets/message-bus.spec.js
+++ b/spec/assets/message-bus.spec.js
@@ -65,4 +65,13 @@ describe("Messagebus", function() {
     })
   });
 
+  it('removes itself from root namespace when noConflict is called', function(){
+    expect(window.MessageBus).not.toBeUndefined();
+    var mb = window.MessageBus;
+    expect(mb).toEqual(window.MessageBus.noConflict());
+    expect(window.MessageBus).toBeUndefined();
+    // reset it so afterEach has something to work on
+    window.MessageBus = mb;
+  });
+
 });

--- a/spec/assets/support/jasmine.yml
+++ b/spec/assets/support/jasmine.yml
@@ -11,8 +11,8 @@
 #   - dist/**/*.js
 #
 src_files:
-  - assets/message-bus-ajax.js
   - assets/message-bus.js
+  - assets/message-bus-ajax.js
 
 
 # stylesheets


### PR DESCRIPTION
While adding it I also noticed a few missing `var` declarations and switched the ajax implementation from the previous PR to load after MessageBus.

If there's interest I can also add a UMD definition.  I personally don't need that but it's probably the 'right thing' to have.