### PR TITLE
Fixes for XMLHttpRequest when jQuery isn't present

### DIFF
--- a/assets/message-bus-ajax.js
+++ b/assets/message-bus-ajax.js
@@ -11,7 +11,7 @@
   var cacheBuster =  Math.random() * 10000 | 0;
 
   global.MessageBus.ajax = function(options){
-    var XHRImpl = global.MessageBus.xhrImplementation || global.XMLHttpRequest;
+    var XHRImpl = (global.MessageBus && global.MessageBus.xhrImplementation) || global.XMLHttpRequest;
     var xhr = new XHRImpl();
     xhr.dataType = options.dataType;
     var url = options.url;

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -274,7 +274,7 @@
     clientId: clientId,
     alwaysLongPoll: false,
     baseUrl: baseUrl,
-    ajax: (jQuery && jQuery.ajax) || MessageBus.ajaxImplementation,
+    ajax: (jQuery && jQuery.ajax),
     noConflict: function(){
       global.MessageBus = global.MessageBus.previousMessageBus;
       return this;


### PR DESCRIPTION
Apparently on #89 I somehow had jQuery enabled while testing.  I missed that it jQuery wasn't present, the code would attempt to access `MessageBus.ajaxImplementation` before `MessageBus` was set.

This should correct the bugs.  Sorry about the bad code :(