### PR TITLE
MessageBus native ajax implementation added to vendor folder

### DIFF
--- a/vendor/assets/javascripts/message-bus-ajax.js
+++ b/vendor/assets/javascripts/message-bus-ajax.js
@@ -1,0 +1,1 @@
+../../../assets/message-bus-ajax.js


### PR DESCRIPTION
We couldn't import `message-bus-ajax.js` file to our rails project because of it's not reachable with gem package. So I added a symlink to vendor folder for message-bus-ajax.js file.