### PR TITLE
Add headers config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ maxPollInterval|180000|If request to the server start failing, MessageBus will b
 alwaysLongPoll|false|For debugging you may want to disable the "is browser in background" check and always long-poll
 baseUrl|/|If message bus is mounted in a subdirectory of different domain, you may configure it to perform requests there
 ajax|$.ajax or XMLHttpRequest|MessageBus will first attempt to use jQuery and then fallback to a plain XMLHttpRequest version that's contained in the `messsage-bus-ajax.js` file. `messsage-bus-ajax.js` must be loaded after `messsage-bus.js` for it to be used.
-
+headers|{}|Extra headers to be include with request.  Properties and values of object must be valid values for HTTP Headers, i.e. no spaces and control characters.
 **API**:
 
 `MessageBus.diagnostics()` : Returns a log that may be used for diagnostics on the status of message bus

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -123,6 +123,9 @@
     var headers = {
       'X-SILENCE-LOGGER': 'true'
     };
+    for (var name in me.headers){
+      headers[name] = me.headers[name];
+    }
 
     if (!chunked){
       headers["Dont-Chunk"] = 'true';
@@ -274,6 +277,7 @@
     clientId: clientId,
     alwaysLongPoll: false,
     baseUrl: baseUrl,
+    headers: {},
     ajax: (jQuery && jQuery.ajax),
     noConflict: function(){
       global.MessageBus = global.MessageBus.previousMessageBus;

--- a/examples/chat/chat.rb
+++ b/examples/chat/chat.rb
@@ -121,10 +121,7 @@ class Chat < Sinatra::Base
       $(function() {
         var name;
 
-        MessageBus.ajax = function(args){
-          args["headers"]["X-NAME"] = name;
-          return $.ajax(args);
-        };
+        MessageBus.headers["X-NAME"] = name;
 
         var enter = function(name, opts) {
            if (opts && opts.check) {

--- a/spec/assets/SpecHelper.js
+++ b/spec/assets/SpecHelper.js
@@ -24,7 +24,9 @@ var encodeChunks = function(xhr, chunks) {
 beforeEach(function () {
   var spec = this;
 
-  function MockedXMLHttpRequest(options){ this.options = options; }
+  function MockedXMLHttpRequest(){
+    this.headers = {};
+  };
   MockedXMLHttpRequest.prototype.send              = function(){
     this.readyState = 4
     this.responseText = encodeChunks(this, spec.responseChunks);
@@ -35,7 +37,9 @@ beforeEach(function () {
   }
   MockedXMLHttpRequest.prototype.open              = function(){ }
   MockedXMLHttpRequest.prototype.abort             = function(){ }
-  MockedXMLHttpRequest.prototype.setRequestHeader  = function(){ }
+  MockedXMLHttpRequest.prototype.setRequestHeader  = function(k,v){
+    this.headers[k] = v;
+  }
   MockedXMLHttpRequest.prototype.getResponseHeader = function(){
     return 'text/plain; charset=utf-8';
   }

--- a/spec/assets/message-bus.spec.js
+++ b/spec/assets/message-bus.spec.js
@@ -74,4 +74,17 @@ describe("Messagebus", function() {
     window.MessageBus = mb;
   });
 
+  testMB('sends using custom header', function(){
+    MessageBus.headers['X-MB-TEST-VALUE'] = '42';
+    this.perform(function(message, xhr){
+      expect(xhr.headers).toEqual({
+        'X-SILENCE-LOGGER': 'true',
+        'X-MB-TEST-VALUE': '42',
+        'Content-Type': 'application/json'
+      });
+    }).finally(function(){
+      MessageBus.headers = {};
+    })
+  });
+
 });


### PR DESCRIPTION
Adds a `MessageBus.headers` configuration.  As noted on #98 it was previously impossible set custom headers with requests.