### PR TITLE
 get the last globalId and messageId for a channel.

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -73,7 +73,7 @@
         if (callback.channel === message.channel) {
           callback.last_id = message.message_id;
           try {
-            callback.func(message.data);
+            callback.func(message.data, message.global_id, message.message_id);
           }
           catch(e){
             if(console.log) {


### PR DESCRIPTION
Adds 2 extra params to JS-Client subscribe function callback, so that it can subscribe to a point in time, recovering the backlog only after that point.

Since we have the possibility of [specifying a `lastID` in the JS-Client subscribe function](https://github.com/SamSaffron/message_bus/blob/master/assets/message-bus.js#L356) this pull request makes possible to save the lastID (global or local)  of received messages and use it at a later time when client needs to subscribe and wants to receive backlog after a point in time.

Example:
```
MessageBus.unsubscribe('/presence/*');
var lastPresence = getFromLocalStorage('lastPresence') || 0;
MessageBus.subscribe('/presence/user', updateUserPresence, lastPresence );
function updateUserPresence(data, globalId, messageId) {
     console.log('updateUserPresence: ', data);
     lastPresence = messageId;
     saveToLocalStorage('lastPresence', lastPresence);
 }
```

closes #118