### PR TITLE
[ci skip] Update puma instructions for Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ For more information see [Passenger documentation](https://www.phusionpassenger.
 #### Puma
 ```ruby
 # path/to/your/config/puma.rb
-require 'message_bus'
+require 'message_bus' # omit this line for Rails 5
 on_worker_boot do
   MessageBus.after_fork
 end


### PR DESCRIPTION
Requiring message_bus in the puma config, under Rails 5, when running via the `puma` command (but not via `rails s`) causes message_bus to be loaded before the rest of the Rails stack, which keeps it from initializing correctly.

I believe this line is the cause of #70 

You generally won't need to explicitly require it under rails anyway. If it's in your Gemfile it should be required by the time the `after_fork` hook is called.