### PR TITLE
Update middleware.rb

### DIFF
--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -56,25 +56,66 @@ class MessageBus::Rack::Middleware
     end.to_a
     JSON.dump(m)
   end
-
+  # GC helping.
+  PATH_INFO = 'PATH_INFO'.freeze
+  CONTENT_TYPE = 'Content-Type'.freeze
+  SLASH = '/'.freeze
+  BUS_REGEX = /^\/message-bus\//.freeze
+  USE_MATCH = BUS_REGEX.respond_to?(:match?)
+  BROADCAST = '/message-bus/broadcast'.freeze
+  DIAGNOSTICS = '/message-bus/_diagnostics'.freeze
+  CHANNEL = 'channel'.freeze
+  DATA = 'data'.freeze
+  TEXT_HTML = 'text/html'.freeze
+  SENT = 'sent'.freeze
+  NOT_FOUND = 'not found'.freeze
+  MESSAGE_BUS_CHANNEL = 'message_bus.channels'.freeze
+  MESSAGE_BUS_SEQ = 'message_bus.seq'.freeze
+  APPLICATION_JSON = 'application/json'.freeze
+  SEQ = '__seq'.freeze
+  CACHE_CONTROL='Cache-Control'.freeze
+  CACHE_LINE = 'must-revalidate, private, max-age=0'.freeze
+  CONTENT_TYPE_LINE = 'application/json; charset=utf-8'.freeze
+  PRAGMA = 'Pragma'.freeze
+  NO_CACHE= 'no-cache'.freeze
+  EXPIRES= 'Expires'.freeze
+  ZERO = '0'.freeze
+  REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+  OPTIONS = 'OPTIONS'.freeze
+  OK='OK'.freeze
+  QUERY_STRING='QUERY_STRING'.freeze
+  DLP_REGEX=/dlp=t/.freeze
+  HTTP_1_1= 'HTTP/1.1'.freeze
+  HTTP_VERSION='HTTP_VERSION'.freeze
+  HTTP_CHUNK = 'HTTP_DONT_CHUNK'.freeze
+  RACK_HIJACK = 'rack.hijack'.freeze
+  IM_A_TEAPOT = "I'm a teapot, undefined in spec".freeze 
+  ASYNC_CALLBACK = 'async.callback'.freeze
+  X_CONTENT_TYPE_OPTIONS = 'X-Content-Type-Options'.freeze
+  NO_SNIFF = 'nosniff'.freeze
+  TRANSFER_ENCODING = 'Transfer-Encoding'.freeze
+  CHUNKED = 'chunked'.freeze
+  TEXT_CONTENT_TYPE_LINE = 'text/plain; charset=utf-8'.freeze
+  EMPTY_LIST = "[]".freeze
+  
   def call(env)
 
-    return @app.call(env) unless env['PATH_INFO'] =~ /^\/message-bus\//
+    return @app.call(env) unless USE_MATCH ? BUS_REGEX.match?(env[PATH_INFO]) : env[PATH_INFO] =~ BUS_REGEX
 
     # special debug/test route
-    if @bus.allow_broadcast? && env['PATH_INFO'] == '/message-bus/broadcast'.freeze
+    if @bus.allow_broadcast? && env[PATH_INFO] == BROADCAST
         parsed = Rack::Request.new(env)
-        @bus.publish parsed["channel".freeze], parsed["data".freeze]
-        return [200,{"Content-Type".freeze => "text/html".freeze},["sent"]]
+        @bus.publish parsed[CHANNEL], parsed[DATA]
+        return [200,{CONTENT_TYPE => TEXT_HTML},[SENT]]
     end
 
-    if env['PATH_INFO'].start_with? '/message-bus/_diagnostics'.freeze
+    if env[PATH_INFO].start_with? DIAGNOSTICS
       diags = MessageBus::Rack::Diagnostics.new(@app, message_bus: @bus)
       return diags.call(env)
     end
 
-    client_id = env['PATH_INFO'].split("/")[2]
-    return [404, {}, ["not found"]] unless client_id
+    client_id = env[PATH_INFO].split(SLASH)[2]
+    return [404, {}, [NOT_FOUND]] unless client_id
 
     user_id = @bus.user_id_lookup.call(env) if @bus.user_id_lookup
     group_ids = @bus.group_ids_lookup.call(env) if @bus.group_ids_lookup
@@ -86,8 +127,8 @@ class MessageBus::Rack::Middleware
     client = MessageBus::Client.new(message_bus: @bus, client_id: client_id,
                                     user_id: user_id, site_id: site_id, group_ids: group_ids)
 
-    if channels = env['message_bus.channels']
-      if seq = env['message_bus.seq']
+    if channels = env[MESSAGE_BUS_CHANNEL]
+      if seq = env[MESSAGE_BUS_SEQ]
         client.seq = seq.to_i
       end
       channels.each do |k, v|
@@ -95,10 +136,10 @@ class MessageBus::Rack::Middleware
       end
     else
       request = Rack::Request.new(env)
-      is_json = request.content_type && request.content_type.include?('application/json')
+      is_json = request.content_type && request.content_type.include?(APPLICATION_JSON)
       data = is_json ? JSON.parse(request.body.read) : request.POST
       data.each do |k,v|
-        if k == "__seq".freeze
+        if k == SEQ
           client.seq = v.to_i
         else
           client.subscribe(k, v)
@@ -107,10 +148,10 @@ class MessageBus::Rack::Middleware
     end
 
     headers = {}
-    headers["Cache-Control"] = "must-revalidate, private, max-age=0"
-    headers["Content-Type"] = "application/json; charset=utf-8"
-    headers["Pragma"] = "no-cache"
-    headers["Expires"] = "0"
+    headers[CACHE_CONTROL] = CACHE_LINE
+    headers[CONTENT_TYPE] = CONTENT_TYPE_LINE
+    headers[PRAGMA] = NO_CACHE
+    headers[EXPIRES] = ZERO
 
     if @bus.extra_response_headers_lookup
       @bus.extra_response_headers_lookup.call(env).each do |k,v|
@@ -118,16 +159,16 @@ class MessageBus::Rack::Middleware
       end
     end
 
-    if env["REQUEST_METHOD"] == "OPTIONS"
-      return [200, headers, ["OK"]]
+    if env[REQUEST_METHOD] == OPTIONS
+      return [200, headers, [OK]]
     end
 
     long_polling = @bus.long_polling_enabled? &&
-                   env['QUERY_STRING'] !~ /dlp=t/.freeze &&
+                   (USE_MATCH ? !DLP_REGEX.match?(env[QUERY_STRING]) : env[QUERY_STRING] !~ DLP_REGEX) &&
                    @connection_manager.client_count < @bus.max_active_clients
 
-    allow_chunked = env['HTTP_VERSION'.freeze] == 'HTTP/1.1'.freeze
-    allow_chunked &&= !env['HTTP_DONT_CHUNK'.freeze]
+    allow_chunked = env[HTTP_VERSION] == HTTP_1_1
+    allow_chunked &&= !env[HTTP_CHUNK]
     allow_chunked &&= @bus.chunked_encoding_enabled?
 
     client.use_chunked = allow_chunked
@@ -138,7 +179,7 @@ class MessageBus::Rack::Middleware
       client.cancel
       @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
       [200, headers, [self.class.backlog_to_json(backlog)] ]
-    elsif long_polling && env['rack.hijack'] && @bus.rack_hijack_enabled?
+    elsif long_polling && env[RACK_HIJACK] && @bus.rack_hijack_enabled?
       io = env['rack.hijack'].call
       # TODO disable client till deliver backlog is called
       client.io = io
@@ -148,8 +189,8 @@ class MessageBus::Rack::Middleware
         add_client_with_timeout(client)
         client.ensure_first_chunk_sent
       end
-      [418, {}, ["I'm a teapot, undefined in spec"]]
-    elsif long_polling && env['async.callback']
+      [418, {}, [IM_A_TEAPOT]]
+    elsif long_polling && env[ASYNC_CALLBACK]
       response = nil
       # load extension if needed
       begin
@@ -164,9 +205,9 @@ class MessageBus::Rack::Middleware
       end
 
       if allow_chunked
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["Transfer-Encoding"] = "chunked"
-        response.headers["Content-Type"] = "text/plain; charset=utf-8"
+        response.headers[X_CONTENT_TYPE_OPTIONS] = NO_SNIFF
+        response.headers[TRANSFER_ENCODING] = CHUNKED
+        response.headers[CONTENT_TYPE] = TEXT_CONTENT_TYPE_LINE
       end
 
       response.status = 200
@@ -179,7 +220,7 @@ class MessageBus::Rack::Middleware
 
       throw :async
     else
-      [200, headers, ["[]"]]
+      [200, headers, [EMPTY_LIST]]
     end
 
   rescue => e


### PR DESCRIPTION
convert all constant strings, to froze const vars.
performance improvement for the gc cycles. it also uses ruby 2.4 match? for faster regex tests if available