### PR TITLE
Handle missing ActionDispatch::Flash in Railtie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Live chat demo per [examples/chat](https://github.com/SamSaffron/message_bus/tre
 
 If you are looking to contribute to this project here are some ideas
 
-- Build backends for other providers (zeromq, rabbitmq, disque) - currently we support pg and redis. 
+- Build backends for other providers (zeromq, rabbitmq, disque) - currently we support pg and redis.
 - Improve and properly document admin dashboard (add opt-in stats, better diagnostics into queues)
 - Improve general documentation (Add examples, refine existing examples)
 - Make MessageBus a nice website
 - Add optional transports for websocket and shared web workers
-- Add `# frozen_string_literal: true` to all non test files and adjust code to allow for it. 
+- Add `# frozen_string_literal: true` to all non test files and adjust code to allow for it.
 
 ## Can you handle concurrent requests?
 
@@ -83,10 +83,10 @@ MessageBus.publish "/channel", "hello", client_ids: ["XXX","YYY"]
 # message bus determines the user ids and groups based on env
 
 MessageBus.configure(user_id_lookup: proc do |env|
-  # this lookup occurs on JS-client poolings, so that server can retrieve backlog 
+  # this lookup occurs on JS-client poolings, so that server can retrieve backlog
   # for the client considering/matching/filtering user_ids set on published messages
   # if user_id is not set on publish time, any user_id returned here will receive the message
-  
+
   # return the user id here
 end)
 
@@ -334,5 +334,17 @@ after_fork do |server, worker|
 end
 ```
 
-###
+### Middleware stack in Rails
 
+MessageBus middleware has to show up after the session middleware, but depending on how the Rails app is configured that might be either `ActionDispatch::Session::CookieStore` or `ActionDispatch::Session::ActiveRecordStore`. To handle both cases, the middleware is inserted before `ActionDispatch::Flash`.
+
+For APIs or apps that have `ActionDispatch::Flash` deleted from the stack the middleware is pushed to the bottom.
+
+Should you want to manipulate the default behavior please refer to [Rails MiddlewareStackProxy documentation](http://api.rubyonrails.org/classes/Rails/Configuration/MiddlewareStackProxy.html) and alter the order of the middlewares in stack in `app/config/initializers/message_bus.rb`
+
+```ruby
+# config/initializers/message_bus.rb
+Rails.application.config do |config|
+  # do anything you wish with config.middleware here
+end
+```

--- a/lib/message_bus/rails/railtie.rb
+++ b/lib/message_bus/rails/railtie.rb
@@ -11,12 +11,24 @@ class MessageBus::Rails::Railtie < ::Rails::Railtie
     #
     # To handle either case, we insert it before ActionDispatch::Flash.
     #
-    begin
-      app.middleware.insert_before(ActionDispatch::Flash, MessageBus::Rack::Middleware)
-    rescue
+    # For APIs or apps that have ActionDispatch::Flash deleted from the middleware
+    # stack we just push MessageBus to the bottom.
+    if api_only?(app.config) || flash_middleware_deleted?(app.middleware)
       app.middleware.use(MessageBus::Rack::Middleware)
+    else
+      app.middleware.insert_before(ActionDispatch::Flash, MessageBus::Rack::Middleware)
     end
 
     MessageBus.logger = Rails.logger
+  end
+
+  def api_only?(config)
+    return false unless config.respond_to?(:api_only)
+    config.api_only
+  end
+
+  def flash_middleware_deleted?(middleware)
+    ops = middleware.instance_variable_get(:@operations)
+    ops.any? { |m| m[0] == :delete && m[1].include?(ActionDispatch::Flash) }
   end
 end


### PR DESCRIPTION
The middleware config in Rails app operates on a MiddlewareStackProxy which more or less acts as a recorder of the operations that is applied over default stack when the app is initialized, hence a regular `rescue` won't work here.

There are two cases to cover:
1. Someone already "deleted" (meaning it will be deleted in the end but it is not just yet)
   ActionDispatch::Flash from the stack
2. ActionDispatch::Flash was never in the stack

No. 1 happens with Rails4 apps that are configured to be API-only or if someone doesn't want the middleware in their stack.
No. 2 is a Rails5 API-only app behaviour.

To handle either case the initializer in `MessageBus::Rails::Railtie` is looking for both cases and applies the MessageBus middleware appropriately. The default behaviour can be easily changed via regular Rails config block.

```ruby
 # config/initializers/message_bus.rb
Rails.application.config do |config|
  # do anything you wish with config.middleware here
end
```

The config was tested on Rails4, Rails4 API-only, Rails5 and Rails5 API-only.
It should solve #124 