### PR TITLE
don't start message bus in rake tasks

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -116,6 +116,10 @@ module MessageBus::Implementation
     @config[:long_polling_interval] || 25 * 1000
   end
 
+  def off?
+    @off
+  end
+
   def off
     @off = true
   end

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -125,7 +125,7 @@ module MessageBus::Implementation
   end
 
   def on
-    @off = false
+    @destroyed = @off = false
   end
 
   def configure(config)
@@ -319,6 +319,8 @@ module MessageBus::Implementation
 
   def destroy
     @mutex.synchronize do
+      return if @destroyed
+
       @subscriptions ||= {}
       reliable_pub_sub.global_unsubscribe
       @destroyed = true

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -36,7 +36,7 @@ class MessageBus::Rack::Middleware
     @app = app
     @bus = config[:message_bus] || MessageBus
     @connection_manager = MessageBus::ConnectionManager.new(@bus)
-    self.start_listener
+    self.start_listener unless @bus.off?
   end
 
   def stop_listener

--- a/lib/message_bus/rails/railtie.rb
+++ b/lib/message_bus/rails/railtie.rb
@@ -23,6 +23,10 @@ class MessageBus::Rails::Railtie < ::Rails::Railtie
     MessageBus.logger = Rails.logger
   end
 
+  rake_tasks do
+    MessageBus.off
+  end
+
   def api_only?(config)
     return false unless config.respond_to?(:api_only)
     config.api_only

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -111,6 +111,19 @@ describe MessageBus::Rack::Middleware do
     include LongPolling
   end
 
+  describe "start listener" do
+    let(:app) { ->(_){ [200, {}, []] } }
+
+
+    it "never subscribes" do
+      bus = Minitest::Mock.new
+      bus.expect(:off?, true)
+
+      MessageBus::Rack::Middleware.new(app,message_bus: bus)
+    end
+
+  end
+
   describe "diagnostics" do
 
     it "should return a 403 if a user attempts to get at the _diagnostics path" do

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -18,6 +18,12 @@ describe MessageBus do
     @bus.destroy
   end
 
+  it "can be turned off" do
+    @bus.off
+
+    @bus.off?.must_equal true
+  end
+
   it "can subscribe from a point in time" do
     @bus.publish("/minion", "banana")
 

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -24,6 +24,19 @@ describe MessageBus do
     @bus.off?.must_equal true
   end
 
+  it "can call destroy twice" do
+    @bus.destroy
+    @bus.destroy
+  end
+
+  it "can be turned on after destroy" do
+    @bus.destroy
+
+    @bus.on
+
+    @bus.after_fork
+  end
+
   it "can subscribe from a point in time" do
     @bus.publish("/minion", "banana")
 


### PR DESCRIPTION
* turn off message bus by rails railtie when running rake
* don't initialize middleware subscribed when off
* method to detect if message bus is off

Otherwise running MessageBus with PostgreSQL backend will break tasks like dropping database etc.

As there is always opened db connection. 