### PR TITLE
Redis READONLY mesasge is not necessary located at start of string.

### DIFF
--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -150,7 +150,7 @@ LUA
     )
 
   rescue Redis::CommandError => e
-    if queue_in_memory && e.message =~ /^READONLY/
+    if queue_in_memory && e.message =~ /READONLY/
       @lock.synchronize do
         @in_memory_backlog << [channel, data]
         if @in_memory_backlog.length > @max_in_memory_publish_backlog


### PR DESCRIPTION
cc @SamSaffron 