### PR TITLE
Refactor MessageBus::Message.decode to reduce object allocations

### DIFF
--- a/lib/message_bus/message.rb
+++ b/lib/message_bus/message.rb
@@ -11,7 +11,8 @@ class MessageBus::Message < Struct.new(:global_id, :message_id, :channel , :data
 
     global_id  = encoded[0, s1+1].to_i
     message_id = encoded[(s1 + 1), (s2 - s1 - 1)].to_i
-    channel    = encoded[(s2 + 1), (s3 - s2 - 1)].gsub("$$123$$", "|")
+    channel    = encoded[(s2 + 1), (s3 - s2 - 1)]
+    channel.gsub!("$$123$$", "|")
     data       = encoded[(s3 + 1), encoded.size]
 
     MessageBus::Message.new(global_id, message_id, channel, data)

--- a/lib/message_bus/message.rb
+++ b/lib/message_bus/message.rb
@@ -9,8 +9,12 @@ class MessageBus::Message < Struct.new(:global_id, :message_id, :channel , :data
     s2 = encoded.index("|", s1 + 1)
     s3 = encoded.index("|", s2 + 1)
 
-    MessageBus::Message.new(encoded[0..s1].to_i, encoded[(s1 + 1)..s2].to_i,
-                            encoded[(s2 + 1)..(s3 - 1)].gsub("$$123$$", "|"), encoded[(s3 + 1)..-1])
+    global_id  = encoded[0, s1+1].to_i
+    message_id = encoded[(s1 + 1), (s2 - s1 - 1)].to_i
+    channel    = encoded[(s2 + 1), (s3 - s2 - 1)].gsub("$$123$$", "|")
+    data       = encoded[(s3 + 1), encoded.size]
+
+    MessageBus::Message.new(global_id, message_id, channel, data)
   end
 
   # only tricky thing to encode is pipes in a channel name ... do a straight replace


### PR DESCRIPTION
I changed the `decode` method to use positional lookups instead of allocating Range objects. Using ruby 2.4 on my macbook yields a ~25% performance improvement.

```
#benchmark-ips
Warming up --------------------------------------
             decode1    37.131k i/100ms
             decode2    45.849k i/100ms
Calculating -------------------------------------
             decode1    412.939k (± 5.2%) i/s -      2.079M in   5.050547s
             decode2    522.827k (± 3.7%) i/s -      2.613M in   5.005663s

Comparison:
             decode2:   522827.1 i/s
             decode1:   412938.7 i/s - 1.27x  slower

# benchmark-memory
Calculating -------------------------------------
             decode1   432.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
             decode2   272.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
             decode2:        272 allocated
             decode1:        432 allocated - 1.59x more
```

[Benchmark script](https://gist.github.com/jamescook/f00d0850d7df5bf926fefbf461a14850)