### PR TITLE
Fix using global MessageBus, always use the related instance

### DIFF
--- a/lib/message_bus/backends/memory.rb
+++ b/lib/message_bus/backends/memory.rb
@@ -277,7 +277,7 @@ class MessageBus::Memory::ReliablePubSub
         end
       end
     rescue => error
-      MessageBus.logger.warn "#{error} subscribe failed, reconnecting in 1 second. Call stack\n#{error.backtrace.join("\n")}"
+      @config[:logger].warn "#{error} subscribe failed, reconnecting in 1 second. Call stack\n#{error.backtrace.join("\n")}"
       sleep 1
       retry
     end

--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -379,7 +379,7 @@ class MessageBus::Postgres::ReliablePubSub
         end
       end
     rescue => error
-      MessageBus.logger.warn "#{error} subscribe failed, reconnecting in 1 second. Call stack\n#{error.backtrace.join("\n")}"
+      @config[:logger].warn "#{error} subscribe failed, reconnecting in 1 second. Call stack\n#{error.backtrace.join("\n")}"
       sleep 1
       retry
     end

--- a/lib/message_bus/connection_manager.rb
+++ b/lib/message_bus/connection_manager.rb
@@ -36,7 +36,7 @@ class MessageBus::ConnectionManager
         end
 
       rescue => e
-        MessageBus.logger.error "notify clients crash #{e} : #{e.backtrace}"
+        @bus.logger.error "notify clients crash #{e} : #{e.backtrace}"
       end
     end
   end

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -24,7 +24,7 @@ class MessageBus::Rack::Middleware
         if thin_running
           EM.next_tick(&run)
         else
-          MessageBus.timer.queue(&run)
+          @bus.timer.queue(&run)
         end
 
         @started_listener = true
@@ -204,7 +204,7 @@ class MessageBus::Rack::Middleware
   def add_client_with_timeout(client)
     @connection_manager.add_client(client)
 
-    client.cleanup_timer = MessageBus.timer.queue(@bus.long_polling_interval.to_f / 1000) {
+    client.cleanup_timer = @bus.timer.queue(@bus.long_polling_interval.to_f / 1000) {
       begin
         client.cleanup_timer = nil
         client.ensure_closed!


### PR DESCRIPTION
If you are using MessageBus::Instance to create separate instances,
none of that code should call the singleton MessageBus instance.
This fixes all cases where the singleton was used.

In order to implement this, MessageBus::Diagnostics.enable needs
to take an argument for the bus to use.  To retain backwards
compatibility, this argument defaults to MessageBus.