### PR TITLE
Make minPollInterval customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Setting|Default|Info
 enableLongPolling|true|Allow long-polling (provided it is enable by the server)
 callbackInterval|15000|Safeguard to ensure background polling does not exceed this interval (in milliseconds)
 backgroundCallbackInterval|60000|Interval to poll when long polling is disabled (either explicitly or due to browser being in background)
+minPollInterval|100|When polling requests succeed, this is the minimum amount of time to wait before making the next request.
 maxPollInterval|180000|If request to the server start failing, MessageBus will backoff, this is the upper limit of the backoff.
 alwaysLongPoll|false|For debugging you may want to disable the "is browser in background" check and always long-poll
 baseUrl|/|If message bus is mounted in a subdirectory of different domain, you may configure it to perform requests there

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -278,7 +278,7 @@
         var interval;
         try {
           if (gotData || aborted) {
-            interval = 100;
+            interval = me.minPollInterval;
           } else {
             interval = me.callbackInterval;
             if (failCount > 2) {
@@ -328,6 +328,7 @@
     enableLongPolling: true,
     callbackInterval: 15000,
     backgroundCallbackInterval: 60000,
+    minPollInterval: 100,
     maxPollInterval: 3 * 60 * 1000,
     callbacks: callbacks,
     clientId: clientId,

--- a/spec/assets/message-bus.spec.js
+++ b/spec/assets/message-bus.spec.js
@@ -84,6 +84,12 @@ describe("Messagebus", function() {
     window.MessageBus = mb;
   });
 
+  it('respects minPollInterval setting with defaults', function(){
+    expect(MessageBus.minPollInterval).toEqual(100);
+    MessageBus.minPollInterval = 1000;
+    expect(MessageBus.minPollInterval).toEqual(1000);
+  });
+
   testMB('sends using custom header', function(){
     MessageBus.headers['X-MB-TEST-VALUE'] = '42';
     this.perform(function(message, xhr){


### PR DESCRIPTION
If MessageBus receives very high frequency data (~200 events per second in our current use case), _a lot_ of connections get open since the default minimum interval is only 100ms. 

Being able to modify the `minCallbackInterval` allows us to receive fewer requests with larger payloads, causing less strain on the client by minimizing request volume. 

Let me know if our use case is an outlier, but it seems like a relatively harmless change to make this value configurable. 

I was hoping to write better tests, but given the number of stubs that would be required to get this line to execute, I focused tests on ensuring the default is respected, and overridable.

cc: @jmreid

Thanks! 