### PR TITLE
`MesssageBus.publish` accepts `site_id` to explicitly publish to site_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+- FEATURE: `MesssageBus.publish` accepts option `site_id` to publish to a site
+
 16-05-2018
 
 - Version 2.1.5

--- a/README.md
+++ b/README.md
@@ -165,13 +165,19 @@ Polling also requires no special setup, MessageBus will fallback to polling afte
 MessageBus can be used in an environment that hosts multiple sites by multiplexing channels. To use this mode
 
 ```ruby
-# define a site_id lookup method
+# define a site_id lookup method, which is executed
+# when `MessageBus.publish` is called
 MessageBus.configure(site_id_lookup: proc do
   some_method_that_returns_site_id_string
 end)
 
 # you may post messages just to this site
 MessageBus.publish "/channel", "some message"
+
+# you can also choose to pass the `site_id`.
+# This takes precendence over whatever `site_id_lookup`
+# returns
+MessageBus.publish "/channel", "some message", site_id: "site-id"
 
 # you may publish messages to ALL sites using the /global/ prefix
 MessageBus.publish "/global/channel", "will go to all sites"

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -226,10 +226,12 @@ module MessageBus::Implementation
     group_ids = nil
     client_ids = nil
 
+    site_id = nil
     if opts
       user_ids = opts[:user_ids]
       group_ids = opts[:group_ids]
       client_ids = opts[:client_ids]
+      site_id = opts[:site_id]
     end
 
     raise ::MessageBus::InvalidMessage if (user_ids || group_ids) && global?(channel)
@@ -250,7 +252,8 @@ module MessageBus::Implementation
       }
     end
 
-    reliable_pub_sub.publish(encode_channel_name(channel), encoded_data, channel_opts)
+    encoded_channel_name = encode_channel_name(channel, site_id)
+    reliable_pub_sub.publish(encoded_channel_name, encoded_data, channel_opts)
   end
 
   def blocking_subscribe(channel = nil, &blk)

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -159,6 +159,26 @@ describe MessageBus do
     assert_nil @bus.last_message("/nothing")
   end
 
+  describe "#publish" do
+    it "allows publishing to a explicit site" do
+      data, site_id, channel = nil
+
+      @bus.subscribe do |msg|
+        data = msg.data
+        site_id = msg.site_id
+        channel = msg.channel
+      end
+
+      @bus.publish("/chuck", "norris", site_id: "law-and-order")
+
+      wait_for(2000) { data }
+
+      data.must_equal 'norris'
+      site_id.must_equal 'law-and-order'
+      channel.must_equal '/chuck'
+    end
+  end
+
   describe "global subscriptions" do
     before do
       seq = 0


### PR DESCRIPTION
Besides relying on `site_id_lookup`, one can also pass `site_id` in `MessageBus.publish` to publish to a specific site.