### PR TITLE
Fuller interface documentation

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -267,23 +267,6 @@ module MessageBus::Implementation
     end
   end
 
-  ENCODE_SITE_TOKEN = "$|$"
-
-  # encode channel name to include site
-  def encode_channel_name(channel, site_id = nil)
-    if (site_id || site_id_lookup) && !global?(channel)
-      raise ArgumentError.new channel if channel.include? ENCODE_SITE_TOKEN
-
-      "#{channel}#{ENCODE_SITE_TOKEN}#{site_id || site_id_lookup.call}"
-    else
-      channel
-    end
-  end
-
-  def decode_channel_name(channel)
-    channel.split(ENCODE_SITE_TOKEN)
-  end
-
   def subscribe(channel = nil, last_id = -1, &blk)
     subscribe_impl(channel, nil, last_id, &blk)
   end
@@ -387,7 +370,24 @@ module MessageBus::Implementation
     @config[:keepalive_interval] || 60
   end
 
-  protected
+  private
+
+  ENCODE_SITE_TOKEN = "$|$"
+
+  # encode channel name to include site
+  def encode_channel_name(channel, site_id = nil)
+    if (site_id || site_id_lookup) && !global?(channel)
+      raise ArgumentError.new channel if channel.include? ENCODE_SITE_TOKEN
+
+      "#{channel}#{ENCODE_SITE_TOKEN}#{site_id || site_id_lookup.call}"
+    else
+      channel
+    end
+  end
+
+  def decode_channel_name(channel)
+    channel.split(ENCODE_SITE_TOKEN)
+  end
 
   def global?(channel)
     channel && channel.start_with?('/global/'.freeze)

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -55,7 +55,7 @@ class MessageBus::Client
   end
 
   # Closes the client connection
-  def cancel
+  def close
     if cleanup_timer
       # concurrency may nil cleanup timer
       cleanup_timer.cancel rescue nil

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -49,34 +49,6 @@ class MessageBus::Client
     end
   end
 
-  def ensure_closed!
-    return unless in_async?
-
-    if use_chunked
-      write_chunk("[]")
-      if @io
-        @io.write("0\r\n\r\n")
-        @io.close
-        @io = nil
-      end
-      if @async_response
-        @async_response << ("0\r\n\r\n")
-        @async_response.done
-        @async_response = nil
-      end
-    else
-      write_and_close "[]"
-    end
-  rescue
-    # we may have a dead socket, just nil the @io
-    @io = nil
-    @async_response = nil
-  end
-
-  def close
-    ensure_closed!
-  end
-
   def closed?
     !@async_response && !@io
   end
@@ -240,6 +212,30 @@ class MessageBus::Client
       @async_response.done
       @async_response = nil
     end
+  end
+
+  def ensure_closed!
+    return unless in_async?
+
+    if use_chunked
+      write_chunk("[]")
+      if @io
+        @io.write("0\r\n\r\n")
+        @io.close
+        @io = nil
+      end
+      if @async_response
+        @async_response << ("0\r\n\r\n")
+        @async_response.done
+        @async_response = nil
+      end
+    else
+      write_and_close "[]"
+    end
+  rescue
+    # we may have a dead socket, just nil the @io
+    @io = nil
+    @async_response = nil
   end
 
   def messages_to_json(msgs)

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -33,10 +33,6 @@ class MessageBus::Client
     ensure_closed!
   end
 
-  def in_async?
-    @async_response || @io
-  end
-
   def deliver_backlog(backlog)
     if backlog.length > 0
       if use_chunked
@@ -163,7 +159,7 @@ class MessageBus::Client
     r || []
   end
 
-  protected
+  private
 
   # heavily optimised to avoid all uneeded allocations
   NEWLINE = "\r\n".freeze
@@ -248,5 +244,9 @@ class MessageBus::Client
 
   def messages_to_json(msgs)
     MessageBus::Rack::Middleware.backlog_to_json(msgs)
+  end
+
+  def in_async?
+    @async_response || @io
   end
 end

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -3,10 +3,38 @@
 # Represents a connected subscriber and delivers published messages over its
 # connected socket.
 class MessageBus::Client
-  attr_accessor :client_id, :user_id, :group_ids, :connect_time,
-                :subscribed_sets, :site_id, :cleanup_timer,
-                :async_response, :io, :headers, :seq, :use_chunked
+  # @return [String] the unique ID provided by the client
+  attr_accessor :client_id
+  # @return [String,Integer] the user ID the client was authenticated for
+  attr_accessor :user_id
+  # @return [Array<String,Integer>] the group IDs the authenticated client is a member of
+  attr_accessor :group_ids
+  # @return [Time] the time at which the client connected
+  attr_accessor :connect_time
+  # @return [String] the site ID the client was authenticated for; used for hosting multiple
+  attr_accessor :site_id
+  # @return [MessageBus::TimerThread::Cancelable] a timer job that is used to
+  #   auto-disconnect the client at the configured long-polling interval
+  attr_accessor :cleanup_timer
+  # @return [Thin::AsyncResponse, nil]
+  attr_accessor :async_response
+  # @return [IO] the HTTP socket the client is connected on
+  attr_accessor :io
+  # @return [Hash<String => String>] custom headers to include in HTTP responses
+  attr_accessor :headers
+  # @return [Integer] the connection sequence number the client provided when connecting
+  attr_accessor :seq
+  # @return [Boolean] whether or not the client should use chunked encoding
+  attr_accessor :use_chunked
 
+  # @param [Hash] opts
+  # @option opts [String] :client_id the unique ID provided by the client
+  # @option opts [String,Integer] :user_id (`nil`) the user ID the client was authenticated for
+  # @option opts [Array<String,Integer>] :group_ids (`[]`) the group IDs the authenticated client is a member of
+  # @option opts [String] :site_id (`nil`) the site ID the client was authenticated for; used for hosting multiple
+  #   applications or instances of an application against a single message_bus
+  # @option opts [#to_i] :seq (`0`) the connection sequence number the client provided when connecting
+  # @option opts [MessageBus::Instance] :message_bus (`MessageBus`) a specific instance of message_bus
   def initialize(opts)
     self.client_id = opts[:client_id]
     self.user_id = opts[:user_id]
@@ -20,10 +48,13 @@ class MessageBus::Client
     @chunks_sent = 0
   end
 
+  # @yield executed with a lock on the Client instance
+  # @return [void]
   def synchronize
     @lock.synchronize { yield }
   end
 
+  # Closes the client connection
   def cancel
     if cleanup_timer
       # concurrency may nil cleanup timer
@@ -33,6 +64,12 @@ class MessageBus::Client
     ensure_closed!
   end
 
+  # Delivers a backlog of messages to the client, if there is anything in it.
+  # If chunked encoding/streaming is in use, will keep the connection open;
+  # if not, will close it.
+  #
+  # @param [Array<MessageBus::Message>] backlog the set of messages to deliver
+  # @return [void]
   def deliver_backlog(backlog)
     if backlog.length > 0
       if use_chunked
@@ -43,26 +80,41 @@ class MessageBus::Client
     end
   end
 
+  # If no data has yet been sent to the client, sends an empty chunk; prevents
+  # clients from entering a timeout state if nothing is delivered initially.
   def ensure_first_chunk_sent
     if use_chunked && @chunks_sent == 0
       write_chunk("[]")
     end
   end
 
+  # @return [Boolean] whether the connection is closed or not
   def closed?
     !@async_response && !@io
   end
 
+  # Subscribes the client to messages on a channel, optionally from a
+  # defined starting point.
+  #
+  # @param [String] channel the channel to subscribe to
+  # @param [Integer, nil] last_seen_id the ID of the last message the client
+  #   received. If nil, will be subscribed from the head of the backlog.
+  # @return [void]
   def subscribe(channel, last_seen_id)
     last_seen_id = nil if last_seen_id == ""
     last_seen_id ||= @bus.last_id(channel)
     @subscriptions[channel] = last_seen_id.to_i
   end
 
+  # @return [Hash<String => Integer>] the active subscriptions, mapping channel
+  #   names to last seen message IDs
   def subscriptions
     @subscriptions
   end
 
+  # Delivers a message to the client, even if it's empty
+  # @param [MessageBus::Message, nil] msg the message to deliver
+  # @return [void]
   def <<(msg)
     json = messages_to_json([msg])
     if use_chunked
@@ -72,6 +124,9 @@ class MessageBus::Client
     end
   end
 
+  # @param [MessageBus::Message] msg the message in question
+  # @return [Boolean] whether or not the client has permission to receive the
+  #   passed message
   def allowed?(msg)
     allowed = !msg.user_ids || msg.user_ids.include?(self.user_id)
     allowed &&= !msg.client_ids || msg.client_ids.include?(self.client_id)
@@ -84,6 +139,11 @@ class MessageBus::Client
     )
   end
 
+  # @return [Array<MessageBus::Message>] the set of messages the client is due
+  #   to receive, based on its subscriptions and permissions. Includes status
+  #   message if any channels have no messages available and the client
+  #   requested a message newer than the newest on the channel, or when there
+  #   are messages available that the client doesn't have permission for.
   def backlog
     r = []
     new_message_ids = nil

--- a/lib/message_bus/connection_manager.rb
+++ b/lib/message_bus/connection_manager.rb
@@ -8,6 +8,7 @@ class MessageBus::ConnectionManager
   require 'monitor'
   include MonitorMixin
 
+  # @param [MessageBus::Instance] bus the message bus for which to manage connections
   def initialize(bus = nil)
     @clients = {}
     @subscriptions = {}
@@ -15,6 +16,9 @@ class MessageBus::ConnectionManager
     mon_initialize
   end
 
+  # Dispatches a message to any connected clients which are permitted to receive it
+  # @param [MessageBus::Message] msg the message to dispatch
+  # @return [void]
   def notify_clients(msg)
     synchronize do
       begin
@@ -43,6 +47,9 @@ class MessageBus::ConnectionManager
     end
   end
 
+  # Keeps track of a client with an active connection
+  # @param [MessageBus::Client] client the client to track
+  # @return [void]
   def add_client(client)
     synchronize do
       existing = @clients[client.client_id]
@@ -63,6 +70,9 @@ class MessageBus::ConnectionManager
     end
   end
 
+  # Removes a client
+  # @param [MessageBus::Client] c the client to remove
+  # @return [void]
   def remove_client(c)
     synchronize do
       @clients.delete c.client_id
@@ -76,11 +86,23 @@ class MessageBus::ConnectionManager
     end
   end
 
+  # Finds a client by ID
+  # @param [String] client_id the client ID to search by
+  # @return [MessageBus::Client] the client with the specified ID
   def lookup_client(client_id)
     synchronize do
       @clients[client_id]
     end
   end
+
+  # @return [Integer] the number of tracked clients
+  def client_count
+    synchronize do
+      @clients.length
+    end
+  end
+
+  private
 
   def subscribe_client(client, channel)
     synchronize do
@@ -90,12 +112,6 @@ class MessageBus::ConnectionManager
         @subscriptions[client.site_id][channel] = set
       end
       set << client.client_id
-    end
-  end
-
-  def client_count
-    synchronize do
-      @clients.length
     end
   end
 end

--- a/lib/message_bus/connection_manager.rb
+++ b/lib/message_bus/connection_manager.rb
@@ -98,13 +98,4 @@ class MessageBus::ConnectionManager
       @clients.length
     end
   end
-
-  def stats
-    synchronize do
-      {
-        client_count: @clients.length,
-        subscriptions: @subscriptions
-      }
-    end
-  end
 end

--- a/lib/message_bus/connection_manager.rb
+++ b/lib/message_bus/connection_manager.rb
@@ -54,11 +54,11 @@ class MessageBus::ConnectionManager
     synchronize do
       existing = @clients[client.client_id]
       if existing && existing.seq > client.seq
-        client.cancel
+        client.close
       else
         if existing
           remove_client(existing)
-          existing.cancel
+          existing.close
         end
 
         @clients[client.client_id] = client

--- a/lib/message_bus/diagnostics.rb
+++ b/lib/message_bus/diagnostics.rb
@@ -1,5 +1,10 @@
+# MessageBus diagnostics are used for troubleshooting the bus and optimising its configuration
+# @see MessageBus::Rack::Diagnostics
 class MessageBus::Diagnostics
   class << self
+    # Enables diagnostics functionality
+    # @param [MessageBus::Instance] bus a specific instance of message_bus
+    # @return [void]
     def enable(bus = MessageBus)
       full_path = full_process_path
       start_time = Time.now.to_f

--- a/lib/message_bus/diagnostics.rb
+++ b/lib/message_bus/diagnostics.rb
@@ -1,53 +1,57 @@
 class MessageBus::Diagnostics
-  def self.full_process_path
-    begin
-      system = `uname`.strip
-      if system == "Darwin"
-        `ps -o "comm=" -p #{Process.pid}`
-      elsif system == "FreeBSD"
-        `ps -o command -p #{Process.pid}`.split("\n", 2)[1].strip
-      else
-        info = `ps -eo "%p|$|%a" | grep '^\\s*#{Process.pid}'`
-        info.strip.split('|$|')[1]
+  class << self
+    def enable(bus = MessageBus)
+      full_path = full_process_path
+      start_time = Time.now.to_f
+      hostname = self.hostname
+
+      # it may make sense to add a channel per machine/host to streamline
+      #  process to process comms
+      bus.subscribe('/_diagnostics/hup') do |msg|
+        if Process.pid == msg.data["pid"] && hostname == msg.data["hostname"]
+          $shutdown = true
+          sleep 4
+          Process.kill("HUP", $$)
+        end
       end
-    rescue
-      # skip it ... not linux or something weird
-    end
-  end
 
-  def self.hostname
-    begin
-      `hostname`.strip
-    rescue
-      # skip it
-    end
-  end
-
-  def self.enable(bus = MessageBus)
-    full_path = full_process_path
-    start_time = Time.now.to_f
-    hostname = self.hostname
-
-    # it may make sense to add a channel per machine/host to streamline
-    #  process to process comms
-    bus.subscribe('/_diagnostics/hup') do |msg|
-      if Process.pid == msg.data["pid"] && hostname == msg.data["hostname"]
-        $shutdown = true
-        sleep 4
-        Process.kill("HUP", $$)
+      bus.subscribe('/_diagnostics/discover') do |msg|
+        bus.on_connect.call msg.site_id if bus.on_connect
+        bus.publish '/_diagnostics/process-discovery', {
+          pid: Process.pid,
+          process_name: $0,
+          full_path: full_path,
+          uptime: (Time.now.to_f - start_time).to_i,
+          hostname: hostname
+        }, user_ids: [msg.data["user_id"]]
+        bus.on_disconnect.call msg.site_id if bus.on_disconnect
       end
     end
 
-    bus.subscribe('/_diagnostics/discover') do |msg|
-      bus.on_connect.call msg.site_id if bus.on_connect
-      bus.publish '/_diagnostics/process-discovery', {
-        pid: Process.pid,
-        process_name: $0,
-        full_path: full_path,
-        uptime: (Time.now.to_f - start_time).to_i,
-        hostname: hostname
-      }, user_ids: [msg.data["user_id"]]
-      bus.on_disconnect.call msg.site_id if bus.on_disconnect
+    private
+
+    def full_process_path
+      begin
+        system = `uname`.strip
+        if system == "Darwin"
+          `ps -o "comm=" -p #{Process.pid}`
+        elsif system == "FreeBSD"
+          `ps -o command -p #{Process.pid}`.split("\n", 2)[1].strip
+        else
+          info = `ps -eo "%p|$|%a" | grep '^\\s*#{Process.pid}'`
+          info.strip.split('|$|')[1]
+        end
+      rescue
+        # skip it ... not linux or something weird
+      end
+    end
+
+    def hostname
+      begin
+        `hostname`.strip
+      rescue
+        # skip it
+      end
     end
   end
 end

--- a/lib/message_bus/distributed_cache.rb
+++ b/lib/message_bus/distributed_cache.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
-# Like a hash, just does its best to stay in sync across the farm.
-# On boot all instances are blank, but they populate as various processes
-# fill it up.
-
 require 'weakref'
 require 'base64'
 require 'securerandom'
 
 module MessageBus
+  # Like a hash, just does its best to stay in sync across the farm.
+  # On boot all instances are blank, but they populate as various processes
+  # fill it up.
   class DistributedCache
     DEFAULT_SITE_ID = 'default'
 

--- a/lib/message_bus/rack/diagnostics.rb
+++ b/lib/message_bus/rack/diagnostics.rb
@@ -8,6 +8,44 @@ class MessageBus::Rack::Diagnostics
     @bus = config[:message_bus] || MessageBus
   end
 
+  def call(env)
+    return @app.call(env) unless env['PATH_INFO'].start_with? '/message-bus/_diagnostics'
+
+    route = env['PATH_INFO'].split('/message-bus/_diagnostics')[1]
+
+    if @bus.is_admin_lookup.nil? || !@bus.is_admin_lookup.call(env)
+      return [403, {}, ['not allowed']]
+    end
+
+    return index unless route
+
+    if route == '/discover'
+      user_id = @bus.user_id_lookup.call(env)
+      @bus.publish('/_diagnostics/discover', user_id: user_id)
+      return [200, {}, ['ok']]
+    end
+
+    if route =~ /^\/hup\//
+      hostname, pid = route.split('/hup/')[1].split('/')
+      @bus.publish('/_diagnostics/hup', hostname: hostname, pid: pid.to_i)
+      return [200, {}, ['ok']]
+    end
+
+    asset = route.split('/assets/')[1]
+    if asset && !asset !~ /\//
+      content = asset_contents(asset)
+      split = asset.split('.')
+      if split[1] == 'handlebars'
+        content = translate_handlebars(split[0], content)
+      end
+      return [200, { 'content-type' => 'text/javascript;' }, [content]]
+    end
+
+    return [404, {}, ['not found']]
+  end
+
+  private
+
   def js_asset(name)
     return generate_script_tag(name) unless @bus.cache_assets
 
@@ -61,41 +99,5 @@ class MessageBus::Rack::Diagnostics
   # from ember-rails
   def indent(string)
     string.gsub(/$(.)/m, "\\1  ").strip
-  end
-
-  def call(env)
-    return @app.call(env) unless env['PATH_INFO'].start_with? '/message-bus/_diagnostics'
-
-    route = env['PATH_INFO'].split('/message-bus/_diagnostics')[1]
-
-    if @bus.is_admin_lookup.nil? || !@bus.is_admin_lookup.call(env)
-      return [403, {}, ['not allowed']]
-    end
-
-    return index unless route
-
-    if route == '/discover'
-      user_id = @bus.user_id_lookup.call(env)
-      @bus.publish('/_diagnostics/discover', user_id: user_id)
-      return [200, {}, ['ok']]
-    end
-
-    if route =~ /^\/hup\//
-      hostname, pid = route.split('/hup/')[1].split('/')
-      @bus.publish('/_diagnostics/hup', hostname: hostname, pid: pid.to_i)
-      return [200, {}, ['ok']]
-    end
-
-    asset = route.split('/assets/')[1]
-    if asset && !asset !~ /\//
-      content = asset_contents(asset)
-      split = asset.split('.')
-      if split[1] == 'handlebars'
-        content = translate_handlebars(split[0], content)
-      end
-      return [200, { 'content-type' => 'text/javascript;' }, [content]]
-    end
-
-    return [404, {}, ['not found']]
   end
 end

--- a/lib/message_bus/rack/diagnostics.rb
+++ b/lib/message_bus/rack/diagnostics.rb
@@ -2,12 +2,19 @@
 
 module MessageBus::Rack; end
 
+# Accepts requests from clients interested in using diagnostics functionality
+# @see MessageBus::Diagnostics
 class MessageBus::Rack::Diagnostics
+  # @param [Proc] app the rack app
+  # @param [Hash] config
+  # @option config [MessageBus::Instance] :message_bus (`MessageBus`) a specific instance of message_bus
   def initialize(app, config = {})
     @app = app
     @bus = config[:message_bus] || MessageBus
   end
 
+  # Process an HTTP request from a subscriber client
+  # @param [Rack::Request::Env] env the request environment
   def call(env)
     return @app.call(env) unless env['PATH_INFO'].start_with? '/message-bus/_diagnostics'
 

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -125,7 +125,7 @@ class MessageBus::Rack::Middleware
     backlog = client.backlog
 
     if backlog.length > 0 && !allow_chunked
-      client.cancel
+      client.close
       @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
       [200, headers, [self.class.backlog_to_json(backlog)]]
     elsif long_polling && env['rack.hijack'] && @bus.rack_hijack_enabled?
@@ -196,7 +196,7 @@ class MessageBus::Rack::Middleware
 
     client.cleanup_timer = @bus.timer.queue(@bus.long_polling_interval.to_f / 1000) {
       begin
-        client.cancel
+        client.close
         @connection_manager.remove_client(client)
       rescue
         @bus.logger.warn "Failed to clean up client properly: #{$!} #{$!.backtrace}"

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -207,8 +207,7 @@ class MessageBus::Rack::Middleware
 
     client.cleanup_timer = @bus.timer.queue(@bus.long_polling_interval.to_f / 1000) {
       begin
-        client.cleanup_timer = nil
-        client.ensure_closed!
+        client.cancel
         @connection_manager.remove_client(client)
       rescue
         @bus.logger.warn "Failed to clean up client properly: #{$!} #{$!.backtrace}"

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -77,7 +77,7 @@ describe MessageBus::Client do
       chunk2.first["data"].must_equal "a|\r\n|\r\n|b"
 
       @client << MessageBus::Message.new(3, 3, '/test', 'test3')
-      @client.close
+      @client.cancel
 
       data = r.read
 

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -77,7 +77,7 @@ describe MessageBus::Client do
       chunk2.first["data"].must_equal "a|\r\n|\r\n|b"
 
       @client << MessageBus::Message.new(3, 3, '/test', 'test3')
-      @client.cancel
+      @client.close
 
       data = r.read
 

--- a/spec/lib/message_bus/connection_manager_spec.rb
+++ b/spec/lib/message_bus/connection_manager_spec.rb
@@ -45,10 +45,6 @@ describe MessageBus::ConnectionManager do
     @manager.lookup_client(@client.client_id).must_equal @client
   end
 
-  it "should be subscribed to a channel" do
-    @manager.stats[:subscriptions][10]["test"].length == 1
-  end
-
   it "should not notify clients on incorrect site" do
     m = MessageBus::Message.new(1, 1, "test", "data")
     m.site_id = 9


### PR DESCRIPTION
Adds documentation for most of the public interface. In some cases, methods were exposed publicly (or as `protected`) for no reason, and so I reduced the surface area of the public interface somewhat.

Note: if https://github.com/SamSaffron/message_bus/pull/181 is merged first, this will need to be rebased and modified.