### PR TITLE
Allows preventing MessageBus start-up

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,7 +103,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 415
+  Max: 419
 
 # Offense count: 18
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ MessageBus.configure(on_middleware_error: proc do |env, e|
 end)
 ```
 
+#### Disabling message_bus
+
+In certain cases, it is undesirable for message_bus to start up on application start, for example in a Rails application during the `db:create` rake task when using the Postgres backend (which will error trying to connect to the non-existent database to subscribe). You can invoke `MessageBus.off` before the middleware chain is loaded in order to prevent subscriptions and publications from happening; in a Rails app you might do this in an initializer based on some environment variable or some other conditional means.
+
 ### Debugging
 
 When setting up MessageBus, it's useful to manually inspect channels before integrating a client application.

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -524,7 +524,7 @@ module MessageBus::Implementation
 
   # (see MessageBus::Backend::Base#reset!)
   def reset!
-    reliable_pub_sub.reset!
+    reliable_pub_sub.reset! if reliable_pub_sub
   end
 
   # @return [MessageBus::TimerThread] the timer thread used for triggering

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -149,6 +149,11 @@ module MessageBus::Implementation
     @config[:long_polling_interval] || 25 * 1000
   end
 
+  # @return [Boolean] whether the bus is disabled or not
+  def off?
+    @off
+  end
+
   # Disables publication to the bus
   # @return [void]
   def off

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -163,7 +163,7 @@ module MessageBus::Implementation
   # Enables publication to the bus
   # @return [void]
   def on
-    @off = false
+    @destroyed = @off = false
   end
 
   # Overrides existing configuration
@@ -495,6 +495,8 @@ module MessageBus::Implementation
     reliable_pub_sub.global_unsubscribe
 
     @mutex.synchronize do
+      return if @destroyed
+
       @subscriptions ||= {}
       @destroyed = true
     end

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -25,7 +25,8 @@ class MessageBus::Rack::Middleware
   end
 
   # Sets up the middleware to receive subscriber client requests and begins
-  # listening for messages published on the bus for re-distribution
+  # listening for messages published on the bus for re-distribution (unless
+  # the bus is disabled).
   #
   # @param [Proc] app the rack app
   # @param [Hash] config
@@ -34,7 +35,7 @@ class MessageBus::Rack::Middleware
     @app = app
     @bus = config[:message_bus] || MessageBus
     @connection_manager = MessageBus::ConnectionManager.new(@bus)
-    start_listener
+    start_listener unless @bus.off?
   end
 
   # Stops listening for messages on the bus

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -24,6 +24,9 @@ class MessageBus::Rack::Middleware
     JSON.dump(m)
   end
 
+  # @return [Boolean] whether the message listener (subscriber) is started or not)
+  attr_reader :started_listener
+
   # Sets up the middleware to receive subscriber client requests and begins
   # listening for messages published on the bus for re-distribution (unless
   # the bus is disabled).
@@ -35,6 +38,7 @@ class MessageBus::Rack::Middleware
     @app = app
     @bus = config[:message_bus] || MessageBus
     @connection_manager = MessageBus::ConnectionManager.new(@bus)
+    @started_listener = false
     start_listener unless @bus.off?
   end
 

--- a/lib/message_bus/rails/railtie.rb
+++ b/lib/message_bus/rails/railtie.rb
@@ -24,6 +24,10 @@ class MessageBus::Rails::Railtie < ::Rails::Railtie
     MessageBus.logger = Rails.logger
   end
 
+  rake_tasks do
+    MessageBus.off
+  end
+
   def api_only?(config)
     return false unless config.respond_to?(:api_only)
 

--- a/lib/message_bus/rails/railtie.rb
+++ b/lib/message_bus/rails/railtie.rb
@@ -24,10 +24,6 @@ class MessageBus::Rails::Railtie < ::Rails::Railtie
     MessageBus.logger = Rails.logger
   end
 
-  rake_tasks do
-    MessageBus.off
-  end
-
   def api_only?(config)
     return false unless config.respond_to?(:api_only)
 

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -111,6 +111,19 @@ describe MessageBus::Rack::Middleware do
     include LongPolling
   end
 
+  describe "start listener" do
+    let(:app) { ->(_){ [200, {}, []] } }
+
+
+    it "never subscribes" do
+      bus = Minitest::Mock.new
+      bus.expect(:off?, true)
+
+      MessageBus::Rack::Middleware.new(app,message_bus: bus)
+    end
+
+  end
+
   describe "diagnostics" do
     it "should return a 403 if a user attempts to get at the _diagnostics path" do
       get "/message-bus/_diagnostics"

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -112,16 +112,14 @@ describe MessageBus::Rack::Middleware do
   end
 
   describe "start listener" do
-    let(:app) { ->(_){ [200, {}, []] } }
-
+    let(:app) { ->(_) { [200, {}, []] } }
 
     it "never subscribes" do
       bus = Minitest::Mock.new
       bus.expect(:off?, true)
 
-      MessageBus::Rack::Middleware.new(app,message_bus: bus)
+      MessageBus::Rack::Middleware.new(app, message_bus: bus)
     end
-
   end
 
   describe "diagnostics" do

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -115,10 +115,12 @@ describe MessageBus::Rack::Middleware do
     let(:app) { ->(_) { [200, {}, []] } }
 
     it "never subscribes" do
-      bus = Minitest::Mock.new
-      bus.expect(:off?, true)
+      bus = MessageBus::Instance.new
+      bus.off
 
-      MessageBus::Rack::Middleware.new(app, message_bus: bus)
+      middleware = MessageBus::Rack::Middleware.new(app, message_bus: bus)
+
+      middleware.started_listener.must_equal false
     end
   end
 

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -22,6 +22,19 @@ describe MessageBus do
     @bus.off?.must_equal true
   end
 
+  it "can call destroy twice" do
+    @bus.destroy
+    @bus.destroy
+  end
+
+  it "can be turned on after destroy" do
+    @bus.destroy
+
+    @bus.on
+
+    @bus.after_fork
+  end
+
   it "can subscribe from a point in time" do
     @bus.publish("/minion", "banana")
 

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -16,6 +16,12 @@ describe MessageBus do
     @bus.destroy
   end
 
+  it "can be turned off" do
+    @bus.off
+
+    @bus.off?.must_equal true
+  end
+
   it "can subscribe from a point in time" do
     @bus.publish("/minion", "banana")
 


### PR DESCRIPTION
A re-run of https://github.com/SamSaffron/message_bus/pull/152.

This allows MessageBus to be included in an application which is not fully setup yet. Some use cases include:

* Manipulating databases (`rake db:drop` etc) when using the Postgres backend.
* Running rake tasks against partially built environments, such as when deploying to Kubernetes before a Redis container comes up.

TODO:
* [x] Usage documentation. Pending merge of https://github.com/SamSaffron/message_bus/pull/184