### PR TITLE
Performance tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,5 +55,15 @@ end
 desc "Run tests on all backends, plus client JS tests"
 task spec: backends.map { |backend| "spec:#{backend}" } + [:spec_client_js]
 
-desc "Run all tests, link checks and confirm documentation compiles without error"
+desc "Run performance benchmarks on all backends"
+task :performance do
+  begin
+    ENV['MESSAGE_BUS_BACKENDS'] = backends.join(",")
+    sh "#{FileUtils::RUBY} -e \"ARGV.each{|f| load f}\" #{Dir['spec/performance/*.rb'].to_a.join(' ')}"
+  ensure
+    ENV.delete('MESSAGE_BUS_BACKENDS')
+  end
+end
+
+desc "Run all tests, link checks and confirms documentation compiles without error"
 task default: [:spec, :rubocop, :test_doc]

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,19 @@
+def wait_for(timeout_milliseconds = 2000)
+  timeout = (timeout_milliseconds + 0.0) / 1000
+  finish = Time.now + timeout
+
+  Thread.new do
+    sleep(0.001) while Time.now < finish && !yield
+  end.join
+end
+
+def test_config_for_backend(backend)
+  config = { backend: backend }
+  case backend
+  when :redis
+    config[:url] = ENV['REDISURL']
+  when :postgres
+    config[:backend_options] = { host: ENV['PGHOST'], user: ENV['PGUSER'] || ENV['USER'], password: ENV['PGPASSWORD'], dbname: ENV['PGDATABASE'] || 'message_bus_test' }
+  end
+  config
+end

--- a/spec/performance/publish.rb
+++ b/spec/performance/publish.rb
@@ -1,0 +1,43 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', '..', 'lib')
+require 'logger'
+require 'benchmark'
+require 'message_bus'
+
+require_relative "../helpers"
+
+backends = ENV['MESSAGE_BUS_BACKENDS'].split(",").map(&:to_sym)
+channel = "/foo"
+iterations = 10_000
+results = []
+
+puts "Running publication benchmark with #{iterations} iterations on backends: #{backends.inspect}"
+
+puts
+Benchmark.bm(10) do |bm|
+  backends.each do |backend|
+    messages_received = 0
+
+    bus = MessageBus::Instance.new
+    bus.configure(test_config_for_backend(backend))
+
+    bus.after_fork
+    bus.subscribe(channel) do |_message|
+      messages_received += 1
+    end
+
+    bm.report(backend) do
+      iterations.times { bus.publish(channel, "Hello world") }
+      wait_for(2000) { messages_received == iterations }
+    end
+
+    results << "[#{backend}]: #{iterations} messages sent, #{messages_received} received, rate of #{(messages_received.to_f / iterations.to_f) * 100}%"
+
+    bus.reset!
+    bus.destroy
+  end
+end
+puts
+
+results.each do |result|
+  puts result
+end

--- a/spec/performance/publish.rb
+++ b/spec/performance/publish.rb
@@ -12,28 +12,87 @@ results = []
 
 puts "Running publication benchmark with #{iterations} iterations on backends: #{backends.inspect}"
 
+benchmark_publication_only = lambda do |bm, backend|
+  bus = MessageBus::Instance.new
+  bus.configure(test_config_for_backend(backend))
+
+  bm.report("#{backend} - publication only") do
+    iterations.times { bus.publish(channel, "Hello world") }
+  end
+
+  bus.reset!
+  bus.destroy
+end
+
+benchmark_subscription_no_trimming = lambda do |bm, backend|
+  test_title = "#{backend} - subscription no trimming"
+
+  bus = MessageBus::Instance.new
+  bus.configure(test_config_for_backend(backend))
+
+  bus.reliable_pub_sub.max_backlog_size = iterations
+  bus.reliable_pub_sub.max_global_backlog_size = iterations
+
+  messages_received = 0
+  bus.after_fork
+  bus.subscribe(channel) do |_message|
+    messages_received += 1
+  end
+
+  bm.report(test_title) do
+    iterations.times { bus.publish(channel, "Hello world") }
+    wait_for(60000) { messages_received == iterations }
+  end
+
+  results << "[#{test_title}]: #{iterations} messages sent, #{messages_received} received, rate of #{(messages_received.to_f / iterations.to_f) * 100}%"
+
+  bus.reset!
+  bus.destroy
+end
+
+benchmark_subscription_with_trimming = lambda do |bm, backend|
+  test_title = "#{backend} - subscription with trimming"
+
+  bus = MessageBus::Instance.new
+  bus.configure(test_config_for_backend(backend))
+
+  bus.reliable_pub_sub.max_backlog_size = (iterations / 10)
+  bus.reliable_pub_sub.max_global_backlog_size = (iterations / 10)
+
+  messages_received = 0
+  bus.after_fork
+  bus.subscribe(channel) do |_message|
+    messages_received += 1
+  end
+
+  bm.report(test_title) do
+    iterations.times { bus.publish(channel, "Hello world") }
+    wait_for(60000) { messages_received == iterations }
+  end
+
+  results << "[#{test_title}]: #{iterations} messages sent, #{messages_received} received, rate of #{(messages_received.to_f / iterations.to_f) * 100}%"
+
+  bus.reset!
+  bus.destroy
+end
+
 puts
-Benchmark.bm(10) do |bm|
+Benchmark.bm(60) do |bm|
   backends.each do |backend|
-    messages_received = 0
+    benchmark_publication_only.call(bm, backend)
+  end
 
-    bus = MessageBus::Instance.new
-    bus.configure(test_config_for_backend(backend))
+  puts
 
-    bus.after_fork
-    bus.subscribe(channel) do |_message|
-      messages_received += 1
-    end
+  backends.each do |backend|
+    benchmark_subscription_no_trimming.call(bm, backend)
+  end
 
-    bm.report(backend) do
-      iterations.times { bus.publish(channel, "Hello world") }
-      wait_for(2000) { messages_received == iterations }
-    end
+  results << nil
+  puts
 
-    results << "[#{backend}]: #{iterations} messages sent, #{messages_received} received, rate of #{(messages_received.to_f / iterations.to_f) * 100}%"
-
-    bus.reset!
-    bus.destroy
+  backends.each do |backend|
+    benchmark_subscription_with_trimming.call(bm, backend)
   end
 end
 puts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,28 +7,13 @@ require 'message_bus'
 require 'minitest/autorun'
 require 'minitest/spec'
 
+require_relative "helpers"
+
 backend = (ENV['MESSAGE_BUS_BACKEND'] || :redis).to_sym
-MESSAGE_BUS_CONFIG = { backend: backend }
+MESSAGE_BUS_CONFIG = test_config_for_backend(backend)
 require "message_bus/backends/#{backend}"
 PUB_SUB_CLASS = MessageBus::BACKENDS.fetch(backend)
-case backend
-when :redis
-  MESSAGE_BUS_CONFIG.merge!(url: ENV['REDISURL'])
-when :postgres
-  MESSAGE_BUS_CONFIG.merge!(backend_options: { host: ENV['PGHOST'], user: ENV['PGUSER'] || ENV['USER'], password: ENV['PGPASSWORD'], dbname: ENV['PGDATABASE'] || 'message_bus_test' })
-end
 puts "Running with backend: #{backend}"
-
-def wait_for(timeout_milliseconds = 2000)
-  timeout = (timeout_milliseconds + 0.0) / 1000
-  finish = Time.now + timeout
-
-  Thread.new do
-    while Time.now < finish && !yield
-      sleep(0.001)
-    end
-  end.join
-end
 
 def test_only(*backends)
   backend = MESSAGE_BUS_CONFIG[:backend]


### PR DESCRIPTION
Executing this on my laptop I get this:

```
docker-compose run tests rake performance
Starting message_bus_postgres_1 ... done
Starting message_bus_redis_1    ... done
/usr/local/bin/ruby -e "ARGV.each{|f| load f}" spec/performance/publish.rb
Running publication benchmark with 10000 iterations on backends: [:postgres, :redis, :memory]

                                                                   user     system      total        real
postgres - publication only                                    2.880000   1.640000   4.520000 ( 26.512851)
redis - publication only                                       0.870000   0.690000   1.560000 (  3.890986)
memory - publication only                                      1.130000   0.000000   1.130000 (  1.142721)

postgres - subscription no trimming                            3.000000   1.970000   4.970000 ( 28.369772)
redis - subscription no trimming                               2.510000   1.180000   3.690000 (  6.072367)
memory - subscription no trimming                              2.900000   0.000000   2.900000 (  2.909922)

postgres - subscription with trimming                          3.620000   2.030000   5.650000 ( 28.796871)
redis - subscription with trimming                             2.050000   0.940000   2.990000 (  5.231705)
memory - subscription with trimming                            1.340000   0.000000   1.340000 (  1.346209)

[postgres - subscription no trimming]: 10000 messages sent, 10000 received, rate of 100.0%
[redis - subscription no trimming]: 10000 messages sent, 10000 received, rate of 100.0%
[memory - subscription no trimming]: 10000 messages sent, 10000 received, rate of 100.0%

[postgres - subscription with trimming]: 10000 messages sent, 10000 received, rate of 100.0%
[redis - subscription with trimming]: 10000 messages sent, 10000 received, rate of 100.0%
[memory - subscription with trimming]: 10000 messages sent, 10000 received, rate of 100.0%
```