### PR TITLE
on_middleware_error only for internal errors

### DIFF
--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -55,7 +55,13 @@ class MessageBus::Rack::Middleware
   # @param [Rack::Request::Env] env the request environment
   def call(env)
     return @app.call(env) unless env['PATH_INFO'] =~ /^\/message-bus\//
+    
+    handle_request(env)
+  end
 
+  private
+
+  def handle_request(env)
     # special debug/test route
     if @bus.allow_broadcast? && env['PATH_INFO'] == '/message-bus/broadcast'
       parsed = Rack::Request.new(env)
@@ -183,8 +189,6 @@ class MessageBus::Rack::Middleware
       raise
     end
   end
-
-  private
 
   def close_db_connection!
     # IMPORTANT

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -55,7 +55,7 @@ class MessageBus::Rack::Middleware
   # @param [Rack::Request::Env] env the request environment
   def call(env)
     return @app.call(env) unless env['PATH_INFO'] =~ /^\/message-bus\//
-    
+
     handle_request(env)
   end
 


### PR DESCRIPTION
Prior to this change, the `on_middleware_error` error handler was being invoked on all exceptions that hit this middleware, including those which come from lower-level middleware. This has the side-effect of potentially masking exceptions from the Rails application, and is surprising because `on_middleware_error` is assumed to handle only message_bus errors.