### PR TITLE
Fix for the redis backend `is_readonly?` method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+  - FIX: In the redis backend make the `is_readonly?` method compatible with the redis gem both pre and post v4.0 when the `client` attribute was removed
+
 30-04-2019
 
 - Version 2.2.1

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -433,10 +433,11 @@ LUA
         key = "__mb_is_readonly"
 
         begin
+          # disconnect to force a reconnect when attempting to set the key
           # in case we are not connected to the correct server
           # which can happen when sharing ips
-          pub_redis.client.reconnect
-          pub_redis.client.call([:set, key, '1'])
+          pub_redis.disconnect!
+          pub_redis.set(key, '1')
           false
         rescue ::Redis::CommandError => e
           return true if e.message =~ /^READONLY/


### PR DESCRIPTION
Fix to make the `is_readonly?` method compatible with the `redis` gem both pre and post v4.0 when the `client` attribute was removed

This resolves issue #208

For further info this is the commit in the `redis` gem that removed the `client` attribute:
https://github.com/redis/redis-rb/commit/c239abb43c2dce99468bf94652a3c48b31a1041a