### PR TITLE
FIX: Protect Redis config from being manipulated

### DIFF
--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -327,7 +327,7 @@ LUA
       private
 
       def new_redis_connection
-        ::Redis.new(@redis_config)
+        ::Redis.new(@redis_config.dup)
       end
 
       # redis connection used for publishing messages

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -406,4 +406,12 @@ describe PUB_SUB_CLASS do
 
     got.map { |m| m.data }.must_equal ["12"]
   end
+
+  it 'should not lose redis config' do
+    test_only :redis
+    redis_config = { connector: Redis::Client::Connector }
+    @bus.instance_variable_set(:@redis_config, redis_config)
+    @bus.send(:new_redis_connection)
+    expect(@bus.instance_variable_get(:@redis_config)[:connector]).must_equal Redis::Client::Connector
+  end
 end


### PR DESCRIPTION
Redis gem is allowing to pass custom connector as an option. Later, code is removing that option and initialize custom connector:
```
options.delete(:connector).new(@options) # https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L95
```

It works for MessageBus when Redis server is running. When it fails and MessageBus is trying to reconnect, because it is a passing reference to Redis, customer connector is not available anymore.

Therefore, I think it would be better to pass a copy of the original object.