### PR TITLE
CI: Attempt to fix tests running older Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["3.0", "2.7", "2.6"]
         redis: ["5.x", "6.x"]
-        fail-fast: [false]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
9.6 is the oldest postgres version listed on their website, and it'll soon be EOL'd. But, let's see if our tests can pass on this database.