### PR TITLE
CI: add fail-fast: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["3.0", "2.7", "2.6"]
         redis: ["5.x", "6.x"]


### PR DESCRIPTION
In order to see more about what actually fails, let's run all the elements of the testing matrix.

This was extracted from #254 - but is valuable on its own.