### PR TITLE
CI: Name test jobs mentioning Redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} (redis ${{ matrix.redis }})
     services:
       postgres:
         image: postgres:14.0


### PR DESCRIPTION
This PR tries to make the GitHub Actions output easier to scan:

E.g.: `Ruby 2.7 (redis 5.x)`

<img width="302" alt="bild" src="https://user-images.githubusercontent.com/211/138679038-5baaea7b-e317-4d14-a1c1-90b69983227e.png">

Found during investigating Postgres failures. #254 