### PR TITLE
DEV: Downgrade puma to fix the build

### DIFF
--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'http_parser.rb'
   gem.add_development_dependency 'thin'
   gem.add_development_dependency 'rack-test'
-  gem.add_development_dependency 'puma'
+  gem.add_development_dependency 'puma', '6.6.1'
   gem.add_development_dependency 'm'
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'oj'


### PR DESCRIPTION
I'm planning on using Pitchfork in specs instead (to align it with Discourse usage) so this is only to unblock the CI.

(Ideally we'd also fix and test Puma 7)